### PR TITLE
fix: verify OpenClaw Gateway adapter UI enablement (issue #1)

### DIFF
--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -114,6 +114,19 @@ export function OpenClawGatewayConfigFields({
 
       {!isCreate && (
         <>
+          <Field
+            label="OpenClaw Agent ID"
+            hint="Agent session key in OpenClaw (e.g. main, cpto). Defaults to Paperclip internal ID if empty."
+          >
+            <DraftInput
+              value={eff("adapterConfig", "agentId", String(config.agentId ?? ""))}
+              onCommit={(v) => mark("adapterConfig", "agentId", v || undefined)}
+              immediate
+              className={inputClass}
+              placeholder="main"
+            />
+          </Field>
+
           <Field label="Paperclip API URL override">
             <DraftInput
               value={

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -891,7 +891,7 @@ function AdapterEnvironmentResult({ result }: { result: AdapterEnvironmentTestRe
 
 /* ---- Internal sub-components ---- */
 
-const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "opencode_local", "cursor"]);
+const ENABLED_ADAPTER_TYPES = new Set(["claude_local", "codex_local", "opencode_local", "cursor", "openclaw_gateway"]);
 
 /** Display list includes all real adapter types plus UI-only coming-soon entries. */
 const ADAPTER_DISPLAY_LIST: { value: string; label: string; comingSoon: boolean }[] = [

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -22,7 +22,7 @@ const adapterLabels: Record<string, string> = {
   http: "HTTP",
 };
 
-const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "opencode_local", "cursor"]);
+const ENABLED_INVITE_ADAPTERS = new Set(["claude_local", "codex_local", "opencode_local", "cursor", "openclaw_gateway"]);
 
 function dateTime(value: string) {
   return new Date(value).toLocaleString();


### PR DESCRIPTION
## Summary
- verify commit fe5e1ec without re-implementation
- confirm fix scope is limited to:
  - ui/src/components/AgentConfigForm.tsx
  - ui/src/pages/InviteLanding.tsx
  - ui/src/adapters/openclaw-gateway/config-fields.tsx
- verify OpenClaw Gateway is enabled in both UI adapter allowlists
- verify OpenClaw Gateway config fields include Agent ID DraftInput

## Verification
- `pnpm test:run` ✅ (44 files, 178 tests)
- `pnpm -r typecheck` ❌ blocked in `cli` by pre-existing unrelated `disableSignUp` type errors
- `pnpm build` ✅
- `npm run test:compact` ❌ script is not defined in this repo

## Issue
Refs ghostwater-ai/paperclip#1
