### PR TITLE
feat(cli): add agent create/update/delete subcommands

### DIFF
--- a/cli/src/__tests__/agent-client-crud.test.ts
+++ b/cli/src/__tests__/agent-client-crud.test.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildAgentCreatePayload,
+  buildAgentUpdatePayload,
+  parseJsonConfigFlag,
+} from "../commands/client/agent.js";
+
+function createTempJsonFile(contents: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-agent-cli-"));
+  const filePath = path.join(dir, "config.json");
+  fs.writeFileSync(filePath, contents, "utf8");
+  return filePath;
+}
+
+describe("parseJsonConfigFlag", () => {
+  it("parses inline JSON object", async () => {
+    await expect(parseJsonConfigFlag('{"token":"abc"}', "--adapter-config")).resolves.toEqual({
+      token: "abc",
+    });
+  });
+
+  it("parses JSON object from @filepath", async () => {
+    const filePath = createTempJsonFile('{"timeoutMs":5000}');
+    await expect(parseJsonConfigFlag(`@${filePath}`, "--runtime-config")).resolves.toEqual({
+      timeoutMs: 5000,
+    });
+  });
+
+  it("throws deterministic error for invalid inline JSON", async () => {
+    await expect(parseJsonConfigFlag('{"broken"', "--adapter-config"))
+      .rejects.toThrow(/Invalid JSON for --adapter-config/);
+  });
+
+  it("throws deterministic error for unreadable @filepath", async () => {
+    const missingPath = path.join(os.tmpdir(), `missing-${Date.now()}.json`);
+    await expect(parseJsonConfigFlag(`@${missingPath}`, "--runtime-config"))
+      .rejects.toThrow(`Failed to read --runtime-config file '${missingPath}'`);
+  });
+
+  it("throws when JSON is not an object", async () => {
+    await expect(parseJsonConfigFlag("[1,2,3]", "--adapter-config"))
+      .rejects.toThrow(/expected a JSON object/);
+  });
+});
+
+describe("agent payload builders", () => {
+  it("builds create payload with optional fields and parsed config", async () => {
+    const payload = await buildAgentCreatePayload({
+      companyId: "company-1",
+      name: "Builder",
+      adapterType: "process",
+      role: "engineer",
+      title: "Senior Engineer",
+      reportsTo: "agent-manager",
+      adapterConfig: '{"env":{"FOO":"bar"}}',
+      runtimeConfig: '{"maxLoops":3}',
+      budget: "15000",
+    });
+
+    expect(payload).toEqual({
+      name: "Builder",
+      adapterType: "process",
+      role: "engineer",
+      title: "Senior Engineer",
+      reportsTo: "agent-manager",
+      adapterConfig: { env: { FOO: "bar" } },
+      runtimeConfig: { maxLoops: 3 },
+      budgetMonthlyCents: 15000,
+    });
+  });
+
+  it("builds update payload with only provided fields", async () => {
+    const payload = await buildAgentUpdatePayload({
+      name: "Renamed",
+      adapterType: "http",
+      budget: "42",
+    });
+
+    expect(payload).toEqual({
+      name: "Renamed",
+      adapterType: "http",
+      budgetMonthlyCents: 42,
+    });
+  });
+
+  it("rejects invalid adapter type for create", async () => {
+    await expect(
+      buildAgentCreatePayload({
+        companyId: "company-1",
+        name: "Bad Adapter",
+        adapterType: "ssh",
+      }),
+    ).rejects.toThrow(/Invalid --adapter-type/);
+  });
+
+  it("rejects invalid role for update", async () => {
+    await expect(
+      buildAgentUpdatePayload({
+        role: "intern",
+      }),
+    ).rejects.toThrow(/Invalid --role/);
+  });
+});

--- a/cli/src/__tests__/agent-client-crud.test.ts
+++ b/cli/src/__tests__/agent-client-crud.test.ts
@@ -104,6 +104,31 @@ describe("agent payload builders", () => {
       }),
     ).rejects.toThrow(/Invalid --role/);
   });
+
+  it("rejects malformed budget values for create", async () => {
+    const malformedBudgets = ["123abc", "1.5", "", "   ", "10_000"];
+    for (const budget of malformedBudgets) {
+      await expect(
+        buildAgentCreatePayload({
+          companyId: "company-1",
+          name: "Budget Checker",
+          adapterType: "process",
+          budget,
+        }),
+      ).rejects.toThrow(/Invalid --budget value/);
+    }
+  });
+
+  it("rejects malformed budget values for update", async () => {
+    const malformedBudgets = ["123abc", "1.5", "", "   ", "10_000"];
+    for (const budget of malformedBudgets) {
+      await expect(
+        buildAgentUpdatePayload({
+          budget,
+        }),
+      ).rejects.toThrow(/Invalid --budget value/);
+    }
+  });
 });
 
 describe("executeAgentDelete", () => {

--- a/cli/src/__tests__/agent-client-crud.test.ts
+++ b/cli/src/__tests__/agent-client-crud.test.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildAgentCreatePayload,
   buildAgentUpdatePayload,
+  executeAgentDelete,
   parseJsonConfigFlag,
 } from "../commands/client/agent.js";
 
@@ -102,5 +103,100 @@ describe("agent payload builders", () => {
         role: "intern",
       }),
     ).rejects.toThrow(/Invalid --role/);
+  });
+});
+
+describe("executeAgentDelete", () => {
+  it("does not call delete when confirmation is declined", async () => {
+    const deleteSpy = vi.fn().mockResolvedValue(null);
+    const confirmDelete = vi.fn().mockResolvedValue(false);
+
+    const result = await executeAgentDelete(
+      "agent-123",
+      { apiBase: "http://localhost:3100" },
+      {
+        resolveContext: () => ({
+          api: { delete: deleteSpy } as any,
+          companyId: undefined,
+          profileName: "default",
+          profile: {} as any,
+          json: false,
+        }),
+        confirmDelete,
+      },
+    );
+
+    expect(confirmDelete).toHaveBeenCalledWith("agent-123");
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      deleted: false,
+      payload: {
+        ok: false,
+        cancelled: true,
+        deletedAgentId: "agent-123",
+      },
+      json: false,
+    });
+  });
+
+  it("calls delete when confirmation is accepted", async () => {
+    const deleteSpy = vi.fn().mockResolvedValue(null);
+    const confirmDelete = vi.fn().mockResolvedValue(true);
+
+    const result = await executeAgentDelete(
+      "agent-456",
+      { apiBase: "http://localhost:3100" },
+      {
+        resolveContext: () => ({
+          api: { delete: deleteSpy } as any,
+          companyId: undefined,
+          profileName: "default",
+          profile: {} as any,
+          json: true,
+        }),
+        confirmDelete,
+      },
+    );
+
+    expect(confirmDelete).toHaveBeenCalledWith("agent-456");
+    expect(deleteSpy).toHaveBeenCalledWith("/api/agents/agent-456");
+    expect(result).toEqual({
+      deleted: true,
+      payload: {
+        ok: true,
+        deletedAgentId: "agent-456",
+      },
+      json: true,
+    });
+  });
+
+  it("skips prompt and calls delete when --yes is passed", async () => {
+    const deleteSpy = vi.fn().mockResolvedValue(null);
+    const confirmDelete = vi.fn().mockResolvedValue(false);
+
+    const result = await executeAgentDelete(
+      "agent-789",
+      {
+        apiBase: "http://localhost:3100",
+        yes: true,
+      },
+      {
+        resolveContext: () => ({
+          api: { delete: deleteSpy } as any,
+          companyId: undefined,
+          profileName: "default",
+          profile: {} as any,
+          json: false,
+        }),
+        confirmDelete,
+      },
+    );
+
+    expect(confirmDelete).not.toHaveBeenCalled();
+    expect(deleteSpy).toHaveBeenCalledWith("/api/agents/agent-789");
+    expect(result.payload).toEqual({
+      ok: true,
+      deletedAgentId: "agent-789",
+    });
   });
 });

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import * as p from "@clack/prompts";
 import { AGENT_ADAPTER_TYPES, AGENT_ROLES, type Agent } from "@paperclipai/shared";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -11,6 +12,7 @@ import {
   printOutput,
   resolveCommandContext,
   type BaseClientOptions,
+  type ResolvedClientContext,
 } from "./common.js";
 
 interface AgentListOptions extends BaseClientOptions {
@@ -39,6 +41,10 @@ interface AgentUpdateOptions extends BaseClientOptions {
   budget?: string;
   title?: string;
   reportsTo?: string;
+}
+
+interface AgentDeleteOptions extends BaseClientOptions {
+  yes?: boolean;
 }
 
 interface AgentLocalCliOptions extends BaseClientOptions {
@@ -82,6 +88,28 @@ interface AgentMutationPayload {
   reportsTo?: string;
 }
 
+interface AgentDeleteExecutionDeps {
+  resolveContext?: (options: BaseClientOptions, opts?: { requireCompany?: boolean }) => ResolvedClientContext;
+  confirmDelete?: (agentId: string) => Promise<boolean>;
+}
+
+interface AgentDeleteSuccessPayload {
+  ok: true;
+  deletedAgentId: string;
+}
+
+interface AgentDeleteCancelledPayload {
+  ok: false;
+  cancelled: true;
+  deletedAgentId: string;
+}
+
+interface AgentDeleteExecutionResult {
+  deleted: boolean;
+  payload: AgentDeleteSuccessPayload | AgentDeleteCancelledPayload;
+  json: boolean;
+}
+
 function omitUndefined<T extends Record<string, unknown>>(input: T): T {
   return Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined)) as T;
 }
@@ -106,6 +134,61 @@ function parseEnumFlag(value: string | undefined, values: readonly string[], fla
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function promptAgentDeleteConfirmation(agentId: string): Promise<boolean> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error("Confirmation requires an interactive terminal. Re-run with --yes to skip the prompt.");
+  }
+
+  const answer = await p.confirm({
+    message: `Delete agent '${agentId}'? This action cannot be undone.`,
+    initialValue: false,
+  });
+
+  if (p.isCancel(answer)) {
+    return false;
+  }
+
+  return answer;
+}
+
+export async function executeAgentDelete(
+  agentId: string,
+  opts: AgentDeleteOptions,
+  deps: AgentDeleteExecutionDeps = {},
+): Promise<AgentDeleteExecutionResult> {
+  const resolveContext = deps.resolveContext ?? resolveCommandContext;
+  const confirmDelete = deps.confirmDelete ?? promptAgentDeleteConfirmation;
+  const ctx = resolveContext(opts);
+
+  let shouldDelete = Boolean(opts.yes);
+  if (!shouldDelete) {
+    shouldDelete = await confirmDelete(agentId);
+  }
+
+  if (!shouldDelete) {
+    return {
+      deleted: false,
+      payload: {
+        ok: false,
+        cancelled: true,
+        deletedAgentId: agentId,
+      },
+      json: ctx.json,
+    };
+  }
+
+  await ctx.api.delete(`/api/agents/${agentId}`);
+
+  return {
+    deleted: true,
+    payload: {
+      ok: true,
+      deletedAgentId: agentId,
+    },
+    json: ctx.json,
+  };
 }
 
 export async function parseJsonConfigFlag(
@@ -339,6 +422,33 @@ export function registerAgentCommands(program: Command): void {
               budgetMonthlyCents: updated.budgetMonthlyCents,
             }),
           );
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("delete")
+      .description("Delete an agent (destructive)")
+      .argument("<agentId>", "Agent ID")
+      .option("-y, --yes", "Skip confirmation prompt", false)
+      .action(async (agentId: string, opts: AgentDeleteOptions) => {
+        try {
+          const result = await executeAgentDelete(agentId, opts);
+
+          if (result.json) {
+            printOutput(result.payload, { json: true });
+            return;
+          }
+
+          if (!result.deleted) {
+            console.log(`Cancelled deletion for agent ${agentId}.`);
+            return;
+          }
+
+          console.log(`Deleted agent ${agentId}.`);
         } catch (err) {
           handleCommandError(err);
         }

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -116,8 +116,12 @@ function omitUndefined<T extends Record<string, unknown>>(input: T): T {
 
 function parseAgentBudget(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) {
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`Invalid --budget value '${value}'. Expected a non-negative integer.`);
+  }
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
     throw new Error(`Invalid --budget value '${value}'. Expected a non-negative integer.`);
   }
   return parsed;

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import type { Agent } from "@paperclipai/shared";
+import { AGENT_ADAPTER_TYPES, AGENT_ROLES, type Agent } from "@paperclipai/shared";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -15,6 +15,30 @@ import {
 
 interface AgentListOptions extends BaseClientOptions {
   companyId?: string;
+}
+
+interface AgentCreateOptions extends BaseClientOptions {
+  companyId?: string;
+  name: string;
+  adapterType: string;
+  role?: string;
+  title?: string;
+  reportsTo?: string;
+  adapterConfig?: string;
+  runtimeConfig?: string;
+  budget?: string;
+}
+
+interface AgentUpdateOptions extends BaseClientOptions {
+  name?: string;
+  role?: string;
+  status?: string;
+  adapterType?: string;
+  adapterConfig?: string;
+  runtimeConfig?: string;
+  budget?: string;
+  title?: string;
+  reportsTo?: string;
 }
 
 interface AgentLocalCliOptions extends BaseClientOptions {
@@ -43,6 +67,108 @@ const PAPERCLIP_SKILLS_CANDIDATES = [
   path.resolve(__moduleDir, "../../../../../skills"), // dev: cli/src/commands/client -> repo root/skills
   path.resolve(process.cwd(), "skills"),
 ];
+const AGENT_ADAPTER_TYPE_VALUES = [...AGENT_ADAPTER_TYPES] as readonly string[];
+const AGENT_ROLE_VALUES = [...AGENT_ROLES] as readonly string[];
+
+interface AgentMutationPayload {
+  name?: string;
+  role?: string;
+  status?: string;
+  adapterType?: string;
+  adapterConfig?: Record<string, unknown>;
+  runtimeConfig?: Record<string, unknown>;
+  budgetMonthlyCents?: number;
+  title?: string;
+  reportsTo?: string;
+}
+
+function omitUndefined<T extends Record<string, unknown>>(input: T): T {
+  return Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined)) as T;
+}
+
+function parseAgentBudget(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Invalid --budget value '${value}'. Expected a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function parseEnumFlag(value: string | undefined, values: readonly string[], flagName: string): string | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim();
+  if (!values.includes(normalized)) {
+    throw new Error(`Invalid ${flagName} '${value}'. Allowed: ${values.join(", ")}`);
+  }
+  return normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function parseJsonConfigFlag(
+  rawValue: string | undefined,
+  flagName: "--adapter-config" | "--runtime-config",
+): Promise<Record<string, unknown> | undefined> {
+  if (rawValue === undefined) return undefined;
+
+  const trimmed = rawValue.trim();
+  const fromPath = trimmed.startsWith("@");
+  const sourceHint = fromPath ? trimmed.slice(1).trim() : undefined;
+  if (fromPath && !sourceHint) {
+    throw new Error(`Invalid ${flagName} value: missing file path after '@'.`);
+  }
+  const filePath = sourceHint as string | undefined;
+  const source = fromPath
+    ? await fs.readFile(filePath!, { encoding: "utf8" }).catch((error) => {
+        const reason = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to read ${flagName} file '${filePath}': ${reason}`);
+      })
+    : rawValue;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON for ${flagName}: ${reason}`);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error(`Invalid JSON for ${flagName}: expected a JSON object.`);
+  }
+
+  return parsed;
+}
+
+export async function buildAgentCreatePayload(opts: AgentCreateOptions): Promise<Required<Pick<AgentMutationPayload, "name" | "adapterType">> & AgentMutationPayload> {
+  return omitUndefined({
+    name: opts.name,
+    adapterType: parseEnumFlag(opts.adapterType, AGENT_ADAPTER_TYPE_VALUES, "--adapter-type")!,
+    role: parseEnumFlag(opts.role, AGENT_ROLE_VALUES, "--role"),
+    title: opts.title,
+    reportsTo: opts.reportsTo,
+    adapterConfig: await parseJsonConfigFlag(opts.adapterConfig, "--adapter-config"),
+    runtimeConfig: await parseJsonConfigFlag(opts.runtimeConfig, "--runtime-config"),
+    budgetMonthlyCents: parseAgentBudget(opts.budget),
+  });
+}
+
+export async function buildAgentUpdatePayload(opts: AgentUpdateOptions): Promise<AgentMutationPayload> {
+  return omitUndefined({
+    name: opts.name,
+    role: parseEnumFlag(opts.role, AGENT_ROLE_VALUES, "--role"),
+    status: opts.status,
+    adapterType: parseEnumFlag(opts.adapterType, AGENT_ADAPTER_TYPE_VALUES, "--adapter-type"),
+    adapterConfig: await parseJsonConfigFlag(opts.adapterConfig, "--adapter-config"),
+    runtimeConfig: await parseJsonConfigFlag(opts.runtimeConfig, "--runtime-config"),
+    budgetMonthlyCents: parseAgentBudget(opts.budget),
+    title: opts.title,
+    reportsTo: opts.reportsTo,
+  });
+}
 
 function codexSkillsHome(): string {
   const fromEnv = process.env.CODEX_HOME?.trim();
@@ -120,6 +246,104 @@ function buildAgentEnvExports(input: {
 
 export function registerAgentCommands(program: Command): void {
   const agent = program.command("agent").description("Agent operations");
+
+  addCommonClientOptions(
+    agent
+      .command("create")
+      .description("Create an agent")
+      .requiredOption("-C, --company-id <id>", "Company ID")
+      .requiredOption("--name <name>", "Agent name")
+      .requiredOption(
+        "--adapter-type <type>",
+        `Adapter type (${AGENT_ADAPTER_TYPE_VALUES.join(", ")})`,
+      )
+      .option("--role <role>", `Agent role (${AGENT_ROLE_VALUES.join(", ")})`)
+      .option("--title <title>", "Agent title")
+      .option("--reports-to <agentId>", "Manager agent ID")
+      .option("--adapter-config <jsonOrFile>", "Adapter config JSON or @path/to/file.json")
+      .option("--runtime-config <jsonOrFile>", "Runtime config JSON or @path/to/file.json")
+      .option("--budget <cents>", "Monthly budget in cents (integer)")
+      .action(async (opts: AgentCreateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts, { requireCompany: true });
+          const payload = await buildAgentCreatePayload(opts);
+          const created = await ctx.api.post<Agent>(`/api/companies/${ctx.companyId}/agents`, payload);
+          if (!created) {
+            throw new Error("Create agent request returned no data");
+          }
+
+          if (ctx.json) {
+            printOutput(created, { json: true });
+            return;
+          }
+
+          console.log(
+            formatInlineRecord({
+              id: created.id,
+              name: created.name,
+              role: created.role,
+              status: created.status,
+              title: created.title,
+              reportsTo: created.reportsTo,
+              adapterType: created.adapterType,
+              budgetMonthlyCents: created.budgetMonthlyCents,
+            }),
+          );
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+    { includeCompany: false },
+  );
+
+  addCommonClientOptions(
+    agent
+      .command("update")
+      .description("Update an agent")
+      .argument("<agentId>", "Agent ID")
+      .option("--name <name>", "Agent name")
+      .option("--role <role>", `Agent role (${AGENT_ROLE_VALUES.join(", ")})`)
+      .option("--status <status>", "Agent status")
+      .option(
+        "--adapter-type <type>",
+        `Adapter type (${AGENT_ADAPTER_TYPE_VALUES.join(", ")})`,
+      )
+      .option("--adapter-config <jsonOrFile>", "Adapter config JSON or @path/to/file.json")
+      .option("--runtime-config <jsonOrFile>", "Runtime config JSON or @path/to/file.json")
+      .option("--budget <cents>", "Monthly budget in cents (integer)")
+      .option("--title <title>", "Agent title")
+      .option("--reports-to <agentId>", "Manager agent ID")
+      .action(async (agentId: string, opts: AgentUpdateOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const payload = await buildAgentUpdatePayload(opts);
+          const updated = await ctx.api.patch<Agent>(`/api/agents/${agentId}`, payload);
+          if (!updated) {
+            throw new Error("Update agent request returned no data");
+          }
+
+          if (ctx.json) {
+            printOutput(updated, { json: true });
+            return;
+          }
+
+          console.log(
+            formatInlineRecord({
+              id: updated.id,
+              name: updated.name,
+              role: updated.role,
+              status: updated.status,
+              title: updated.title,
+              reportsTo: updated.reportsTo,
+              adapterType: updated.adapterType,
+              budgetMonthlyCents: updated.budgetMonthlyCents,
+            }),
+          );
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+  );
 
   addCommonClientOptions(
     agent


### PR DESCRIPTION
## Summary
- add `paperclipai agent create` with required `--company-id`, `--name`, and `--adapter-type` plus optional role/title/reports/config/budget flags
- add `paperclipai agent update <agentId>` with optional mutable fields and PATCH payload shaping
- add `paperclipai agent delete <agentId>` with interactive confirmation and `--yes/-y` bypass
- support `--adapter-config` and `--runtime-config` as inline JSON or `@file` JSON
- add tests for config parsing, create/update payload builders, and delete execution flows

## Verification
- `pnpm test:run` ✅
- `pnpm build` ✅
- `pnpm -r typecheck` ⚠️ fails from pre-existing CLI typing errors unrelated to this change (`disableSignUp` missing in several files)

Closes #5
