### PR TITLE
feat: implement OpenClaw session key routing across backend and UI

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -129,11 +129,9 @@ function normalizeSessionKeyStrategy(value: unknown): SessionKeyStrategy {
 function resolveSessionKey(input: {
   strategy: SessionKeyStrategy;
   configuredSessionKey: string | null;
-  projectSessionKey: string | null;
   runId: string;
   issueId: string | null;
 }): string {
-  if (input.projectSessionKey) return input.projectSessionKey;
   const fallback = input.configuredSessionKey ?? "paperclip";
   if (input.strategy === "run") return `paperclip:run:${input.runId}`;
   if (input.strategy === "issue" && input.issueId) return `paperclip:issue:${input.issueId}`;
@@ -228,7 +226,6 @@ export function resolveSessionKeyFromRouting(input: {
   return resolveSessionKey({
     strategy: input.fallback.strategy,
     configuredSessionKey: input.fallback.configuredSessionKey,
-    projectSessionKey: input.projectSessionKey,
     runId: input.runId,
     issueId: input.issueId,
   });

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -188,6 +188,7 @@ export function interpolateTemplate(
 }
 
 export function resolveSessionKeyFromRouting(input: {
+  projectRoutingRules?: SessionKeyRoutingRule[] | null;
   routingRules: SessionKeyRoutingRule[];
   wakeSource: string | null;
   wakeReason: string | null;
@@ -215,7 +216,10 @@ export function resolveSessionKeyFromRouting(input: {
     wakeReason: nonEmpty(input.wakeReason),
   };
 
-  for (const rule of input.routingRules) {
+  const projectRoutingRules = Array.isArray(input.projectRoutingRules) ? input.projectRoutingRules : [];
+  const orderedRules = [...projectRoutingRules, ...input.routingRules];
+
+  for (const rule of orderedRules) {
     if (!matchPattern(sourceAndReason, rule.pattern)) continue;
     const resolved = interpolateTemplate(rule.sessionKey, variables);
     if (resolved) return resolved;
@@ -1012,8 +1016,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);
   const projectSessionKey = nonEmpty(ctx.context.projectSessionKey);
+  const projectRoutingRules = parseSessionKeyRouting(ctx.context.projectSessionKeyRouting);
   const routingRules = parseSessionKeyRouting(ctx.config.sessionKeyRouting);
   const sessionKey = resolveSessionKeyFromRouting({
+    projectRoutingRules,
     routingRules,
     wakeSource: nonEmpty(ctx.context.wakeSource),
     wakeReason: wakePayload.wakeReason,

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -4,6 +4,10 @@ import crypto, { randomUUID } from "node:crypto";
 import { WebSocket } from "ws";
 
 type SessionKeyStrategy = "fixed" | "issue" | "run";
+export type SessionKeyRoutingRule = {
+  pattern: string;
+  sessionKey: string;
+};
 
 type WakePayload = {
   runId: string;
@@ -134,6 +138,96 @@ function resolveSessionKey(input: {
   if (input.strategy === "run") return `paperclip:run:${input.runId}`;
   if (input.strategy === "issue" && input.issueId) return `paperclip:issue:${input.issueId}`;
   return fallback;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseSessionKeyRouting(value: unknown): SessionKeyRoutingRule[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => asRecord(entry))
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+    .map((entry) => ({
+      pattern: nonEmpty(entry.pattern),
+      sessionKey: nonEmpty(entry.sessionKey),
+    }))
+    .filter((entry): entry is SessionKeyRoutingRule => Boolean(entry.pattern && entry.sessionKey));
+}
+
+export function matchPattern(sourceAndReason: string, pattern: string): boolean {
+  const trimmedPattern = pattern.trim();
+  if (!trimmedPattern) return false;
+  if (trimmedPattern === "*") return true;
+
+  const regexPattern = `^${escapeRegExp(trimmedPattern).replace(/\\\*/g, ".*")}$`;
+  return new RegExp(regexPattern).test(sourceAndReason);
+}
+
+export function interpolateTemplate(
+  template: string,
+  variables: Record<string, string | null | undefined>,
+): string | null {
+  if (!template.trim()) return null;
+
+  const matcher = /\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g;
+  let resolved = template;
+  let match: RegExpExecArray | null = null;
+
+  while ((match = matcher.exec(template)) !== null) {
+    const variableName = match[1] ?? "";
+    const variableValue = variables[variableName];
+    const resolvedValue =
+      typeof variableValue === "string" && variableValue.trim().length > 0 ? variableValue.trim() : null;
+    if (!resolvedValue) return null;
+    resolved = resolved.replace(match[0], resolvedValue);
+  }
+
+  return resolved.trim().length > 0 ? resolved : null;
+}
+
+export function resolveSessionKeyFromRouting(input: {
+  routingRules: SessionKeyRoutingRule[];
+  wakeSource: string | null;
+  wakeReason: string | null;
+  runId: string;
+  issueId: string | null;
+  projectId: string | null;
+  projectSessionKey: string | null;
+  agentId: string;
+  fallback: {
+    strategy: SessionKeyStrategy;
+    configuredSessionKey: string | null;
+  };
+}): string {
+  const wakeSource = input.wakeSource ?? "";
+  const wakeReason = input.wakeReason ?? "";
+  const sourceAndReason = `${wakeSource}:${wakeReason}`;
+
+  const variables: Record<string, string | null> = {
+    agentId: nonEmpty(input.agentId),
+    projectId: input.projectId,
+    projectSessionKey: input.projectSessionKey,
+    issueId: input.issueId,
+    runId: nonEmpty(input.runId),
+    wakeSource: nonEmpty(input.wakeSource),
+    wakeReason: nonEmpty(input.wakeReason),
+  };
+
+  for (const rule of input.routingRules) {
+    if (!matchPattern(sourceAndReason, rule.pattern)) continue;
+    const resolved = interpolateTemplate(rule.sessionKey, variables);
+    if (resolved) return resolved;
+  }
+
+  return resolveSessionKey({
+    strategy: input.fallback.strategy,
+    configuredSessionKey: input.fallback.configuredSessionKey,
+    projectSessionKey: input.projectSessionKey,
+    runId: input.runId,
+    issueId: input.issueId,
+  });
 }
 
 function isLoopbackHost(hostname: string): boolean {
@@ -918,12 +1012,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);
   const projectSessionKey = nonEmpty(ctx.context.projectSessionKey);
-  const sessionKey = resolveSessionKey({
-    strategy: sessionKeyStrategy,
-    configuredSessionKey,
-    projectSessionKey,
+  const routingRules = parseSessionKeyRouting(ctx.config.sessionKeyRouting);
+  const sessionKey = resolveSessionKeyFromRouting({
+    routingRules,
+    wakeSource: nonEmpty(ctx.context.wakeSource),
+    wakeReason: wakePayload.wakeReason,
     runId: ctx.runId,
     issueId: wakePayload.issueId,
+    projectId: nonEmpty(ctx.context.projectId),
+    projectSessionKey,
+    agentId: ctx.agent.id,
+    fallback: {
+      strategy: sessionKeyStrategy,
+      configuredSessionKey,
+    },
   });
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);

--- a/packages/adapters/openclaw-gateway/src/server/index.ts
+++ b/packages/adapters/openclaw-gateway/src/server/index.ts
@@ -1,2 +1,8 @@
-export { execute } from "./execute.js";
+export {
+  execute,
+  interpolateTemplate,
+  matchPattern,
+  resolveSessionKeyFromRouting,
+  type SessionKeyRoutingRule,
+} from "./execute.js";
 export { testEnvironment } from "./test.js";

--- a/packages/db/src/migrations/0027_jazzy_gideon.sql
+++ b/packages/db/src/migrations/0027_jazzy_gideon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "projects" ADD COLUMN "session_key_routing" jsonb;

--- a/packages/db/src/migrations/meta/0027_snapshot.json
+++ b/packages/db/src/migrations/meta/0027_snapshot.json
@@ -1,0 +1,5861 @@
+{
+  "id": "c0a9aa6a-c052-4a16-b4d3-1bf41c28caaf",
+  "prevId": "4056a4c7-29d2-4266-867c-ec88ad7834f7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_log_company_created_idx": {
+          "name": "activity_log_company_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_log_run_id_idx": {
+          "name": "activity_log_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_log_entity_type_id_idx": {
+          "name": "activity_log_entity_type_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_company_id_companies_id_fk": {
+          "name": "activity_log_company_id_companies_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_log_agent_id_agents_id_fk": {
+          "name": "activity_log_agent_id_agents_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_log_run_id_heartbeat_runs_id_fk": {
+          "name": "activity_log_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_api_keys": {
+      "name": "agent_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_api_keys_key_hash_idx": {
+          "name": "agent_api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_api_keys_company_agent_idx": {
+          "name": "agent_api_keys_company_agent_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_api_keys_agent_id_agents_id_fk": {
+          "name": "agent_api_keys_agent_id_agents_id_fk",
+          "tableFrom": "agent_api_keys",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_api_keys_company_id_companies_id_fk": {
+          "name": "agent_api_keys_company_id_companies_id_fk",
+          "tableFrom": "agent_api_keys",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config_revisions": {
+      "name": "agent_config_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'patch'"
+        },
+        "rolled_back_from_revision_id": {
+          "name": "rolled_back_from_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_keys": {
+          "name": "changed_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "before_config": {
+          "name": "before_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after_config": {
+          "name": "after_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_config_revisions_company_agent_created_idx": {
+          "name": "agent_config_revisions_company_agent_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_revisions_agent_created_idx": {
+          "name": "agent_config_revisions_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_revisions_company_id_companies_id_fk": {
+          "name": "agent_config_revisions_company_id_companies_id_fk",
+          "tableFrom": "agent_config_revisions",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_config_revisions_agent_id_agents_id_fk": {
+          "name": "agent_config_revisions_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_revisions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_revisions_created_by_agent_id_agents_id_fk": {
+          "name": "agent_config_revisions_created_by_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_revisions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runtime_state": {
+      "name": "agent_runtime_state",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter_type": {
+          "name": "adapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_json": {
+          "name": "state_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_status": {
+          "name": "last_run_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_input_tokens": {
+          "name": "total_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_output_tokens": {
+          "name": "total_output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_cached_input_tokens": {
+          "name": "total_cached_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_cost_cents": {
+          "name": "total_cost_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_runtime_state_company_agent_idx": {
+          "name": "agent_runtime_state_company_agent_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_runtime_state_company_updated_idx": {
+          "name": "agent_runtime_state_company_updated_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runtime_state_agent_id_agents_id_fk": {
+          "name": "agent_runtime_state_agent_id_agents_id_fk",
+          "tableFrom": "agent_runtime_state",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_runtime_state_company_id_companies_id_fk": {
+          "name": "agent_runtime_state_company_id_companies_id_fk",
+          "tableFrom": "agent_runtime_state",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_task_sessions": {
+      "name": "agent_task_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter_type": {
+          "name": "adapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_key": {
+          "name": "task_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_params_json": {
+          "name": "session_params_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_display_id": {
+          "name": "session_display_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_task_sessions_company_agent_adapter_task_uniq": {
+          "name": "agent_task_sessions_company_agent_adapter_task_uniq",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "adapter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_task_sessions_company_agent_updated_idx": {
+          "name": "agent_task_sessions_company_agent_updated_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_task_sessions_company_task_updated_idx": {
+          "name": "agent_task_sessions_company_task_updated_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_task_sessions_company_id_companies_id_fk": {
+          "name": "agent_task_sessions_company_id_companies_id_fk",
+          "tableFrom": "agent_task_sessions",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_task_sessions_agent_id_agents_id_fk": {
+          "name": "agent_task_sessions_agent_id_agents_id_fk",
+          "tableFrom": "agent_task_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_task_sessions_last_run_id_heartbeat_runs_id_fk": {
+          "name": "agent_task_sessions_last_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "agent_task_sessions",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "last_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_wakeup_requests": {
+      "name": "agent_wakeup_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "coalesced_count": {
+          "name": "coalesced_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_id": {
+          "name": "requested_by_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_wakeup_requests_company_agent_status_idx": {
+          "name": "agent_wakeup_requests_company_agent_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_wakeup_requests_company_requested_idx": {
+          "name": "agent_wakeup_requests_company_requested_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_wakeup_requests_agent_requested_idx": {
+          "name": "agent_wakeup_requests_agent_requested_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_wakeup_requests_company_id_companies_id_fk": {
+          "name": "agent_wakeup_requests_company_id_companies_id_fk",
+          "tableFrom": "agent_wakeup_requests",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_wakeup_requests_agent_id_agents_id_fk": {
+          "name": "agent_wakeup_requests_agent_id_agents_id_fk",
+          "tableFrom": "agent_wakeup_requests",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "reports_to": {
+          "name": "reports_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_type": {
+          "name": "adapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'process'"
+        },
+        "adapter_config": {
+          "name": "adapter_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "runtime_config": {
+          "name": "runtime_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "budget_monthly_cents": {
+          "name": "budget_monthly_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "spent_monthly_cents": {
+          "name": "spent_monthly_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_company_status_idx": {
+          "name": "agents_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_company_reports_to_idx": {
+          "name": "agents_company_reports_to_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reports_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_company_id_companies_id_fk": {
+          "name": "agents_company_id_companies_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_reports_to_agents_id_fk": {
+          "name": "agents_reports_to_agents_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "reports_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_comments": {
+      "name": "approval_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_agent_id": {
+          "name": "author_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_comments_company_idx": {
+          "name": "approval_comments_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_comments_approval_idx": {
+          "name": "approval_comments_approval_idx",
+          "columns": [
+            {
+              "expression": "approval_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_comments_approval_created_idx": {
+          "name": "approval_comments_approval_created_idx",
+          "columns": [
+            {
+              "expression": "approval_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_comments_company_id_companies_id_fk": {
+          "name": "approval_comments_company_id_companies_id_fk",
+          "tableFrom": "approval_comments",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "approval_comments_approval_id_approvals_id_fk": {
+          "name": "approval_comments_approval_id_approvals_id_fk",
+          "tableFrom": "approval_comments",
+          "tableTo": "approvals",
+          "columnsFrom": [
+            "approval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "approval_comments_author_agent_id_agents_id_fk": {
+          "name": "approval_comments_author_agent_id_agents_id_fk",
+          "tableFrom": "approval_comments",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "author_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approvals": {
+      "name": "approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_agent_id": {
+          "name": "requested_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approvals_company_status_type_idx": {
+          "name": "approvals_company_status_type_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approvals_company_id_companies_id_fk": {
+          "name": "approvals_company_id_companies_id_fk",
+          "tableFrom": "approvals",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "approvals_requested_by_agent_id_agents_id_fk": {
+          "name": "approvals_requested_by_agent_id_agents_id_fk",
+          "tableFrom": "approvals",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "requested_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assets_company_created_idx": {
+          "name": "assets_company_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_company_provider_idx": {
+          "name": "assets_company_provider_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assets_company_object_key_uq": {
+          "name": "assets_company_object_key_uq",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assets_company_id_companies_id_fk": {
+          "name": "assets_company_id_companies_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assets_created_by_agent_id_agents_id_fk": {
+          "name": "assets_created_by_agent_id_agents_id_fk",
+          "tableFrom": "assets",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.companies": {
+      "name": "companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "issue_prefix": {
+          "name": "issue_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PAP'"
+        },
+        "issue_counter": {
+          "name": "issue_counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "budget_monthly_cents": {
+          "name": "budget_monthly_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "spent_monthly_cents": {
+          "name": "spent_monthly_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "require_board_approval_for_new_agents": {
+          "name": "require_board_approval_for_new_agents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "brand_color": {
+          "name": "brand_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "companies_issue_prefix_idx": {
+          "name": "companies_issue_prefix_idx",
+          "columns": [
+            {
+              "expression": "issue_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_memberships": {
+      "name": "company_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "membership_role": {
+          "name": "membership_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "company_memberships_company_principal_unique_idx": {
+          "name": "company_memberships_company_principal_unique_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_memberships_principal_status_idx": {
+          "name": "company_memberships_principal_status_idx",
+          "columns": [
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_memberships_company_status_idx": {
+          "name": "company_memberships_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_memberships_company_id_companies_id_fk": {
+          "name": "company_memberships_company_id_companies_id_fk",
+          "tableFrom": "company_memberships",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_secret_versions": {
+      "name": "company_secret_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "material": {
+          "name": "material",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_sha256": {
+          "name": "value_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "company_secret_versions_secret_idx": {
+          "name": "company_secret_versions_secret_idx",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_secret_versions_value_sha256_idx": {
+          "name": "company_secret_versions_value_sha256_idx",
+          "columns": [
+            {
+              "expression": "value_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_secret_versions_secret_version_uq": {
+          "name": "company_secret_versions_secret_version_uq",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_secret_versions_secret_id_company_secrets_id_fk": {
+          "name": "company_secret_versions_secret_id_company_secrets_id_fk",
+          "tableFrom": "company_secret_versions",
+          "tableTo": "company_secrets",
+          "columnsFrom": [
+            "secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "company_secret_versions_created_by_agent_id_agents_id_fk": {
+          "name": "company_secret_versions_created_by_agent_id_agents_id_fk",
+          "tableFrom": "company_secret_versions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_secrets": {
+      "name": "company_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local_encrypted'"
+        },
+        "external_ref": {
+          "name": "external_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "company_secrets_company_idx": {
+          "name": "company_secrets_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_secrets_company_provider_idx": {
+          "name": "company_secrets_company_provider_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_secrets_company_name_uq": {
+          "name": "company_secrets_company_name_uq",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_secrets_company_id_companies_id_fk": {
+          "name": "company_secrets_company_id_companies_id_fk",
+          "tableFrom": "company_secrets",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_secrets_created_by_agent_id_agents_id_fk": {
+          "name": "company_secrets_created_by_agent_id_agents_id_fk",
+          "tableFrom": "company_secrets",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cost_events": {
+      "name": "cost_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_code": {
+          "name": "billing_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cost_events_company_occurred_idx": {
+          "name": "cost_events_company_occurred_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cost_events_company_agent_occurred_idx": {
+          "name": "cost_events_company_agent_occurred_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cost_events_company_id_companies_id_fk": {
+          "name": "cost_events_company_id_companies_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cost_events_agent_id_agents_id_fk": {
+          "name": "cost_events_agent_id_agents_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cost_events_issue_id_issues_id_fk": {
+          "name": "cost_events_issue_id_issues_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cost_events_project_id_projects_id_fk": {
+          "name": "cost_events_project_id_projects_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cost_events_goal_id_goals_id_fk": {
+          "name": "cost_events_goal_id_goals_id_fk",
+          "tableFrom": "cost_events",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'task'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_agent_id": {
+          "name": "owner_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "goals_company_idx": {
+          "name": "goals_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "goals_company_id_companies_id_fk": {
+          "name": "goals_company_id_companies_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "goals_parent_id_goals_id_fk": {
+          "name": "goals_parent_id_goals_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "goals_owner_agent_id_agents_id_fk": {
+          "name": "goals_owner_agent_id_agents_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "owner_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.heartbeat_run_events": {
+      "name": "heartbeat_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream": {
+          "name": "stream",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "heartbeat_run_events_run_seq_idx": {
+          "name": "heartbeat_run_events_run_seq_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "heartbeat_run_events_company_run_idx": {
+          "name": "heartbeat_run_events_company_run_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "heartbeat_run_events_company_created_idx": {
+          "name": "heartbeat_run_events_company_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "heartbeat_run_events_company_id_companies_id_fk": {
+          "name": "heartbeat_run_events_company_id_companies_id_fk",
+          "tableFrom": "heartbeat_run_events",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "heartbeat_run_events_run_id_heartbeat_runs_id_fk": {
+          "name": "heartbeat_run_events_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "heartbeat_run_events",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "heartbeat_run_events_agent_id_agents_id_fk": {
+          "name": "heartbeat_run_events_agent_id_agents_id_fk",
+          "tableFrom": "heartbeat_run_events",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.heartbeat_runs": {
+      "name": "heartbeat_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invocation_source": {
+          "name": "invocation_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_demand'"
+        },
+        "trigger_detail": {
+          "name": "trigger_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wakeup_request_id": {
+          "name": "wakeup_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id_before": {
+          "name": "session_id_before",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id_after": {
+          "name": "session_id_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_store": {
+          "name": "log_store",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_ref": {
+          "name": "log_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_bytes": {
+          "name": "log_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_sha256": {
+          "name": "log_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_compressed": {
+          "name": "log_compressed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stdout_excerpt": {
+          "name": "stdout_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stderr_excerpt": {
+          "name": "stderr_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_run_id": {
+          "name": "external_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_snapshot": {
+          "name": "context_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "heartbeat_runs_company_agent_started_idx": {
+          "name": "heartbeat_runs_company_agent_started_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "heartbeat_runs_company_id_companies_id_fk": {
+          "name": "heartbeat_runs_company_id_companies_id_fk",
+          "tableFrom": "heartbeat_runs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "heartbeat_runs_agent_id_agents_id_fk": {
+          "name": "heartbeat_runs_agent_id_agents_id_fk",
+          "tableFrom": "heartbeat_runs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "heartbeat_runs_wakeup_request_id_agent_wakeup_requests_id_fk": {
+          "name": "heartbeat_runs_wakeup_request_id_agent_wakeup_requests_id_fk",
+          "tableFrom": "heartbeat_runs",
+          "tableTo": "agent_wakeup_requests",
+          "columnsFrom": [
+            "wakeup_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_user_roles": {
+      "name": "instance_user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'instance_admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_user_roles_user_role_unique_idx": {
+          "name": "instance_user_roles_user_role_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instance_user_roles_role_idx": {
+          "name": "instance_user_roles_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_type": {
+          "name": "invite_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'company_join'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_join_types": {
+          "name": "allowed_join_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'both'"
+        },
+        "defaults_payload": {
+          "name": "defaults_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_token_hash_unique_idx": {
+          "name": "invites_token_hash_unique_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_company_invite_state_idx": {
+          "name": "invites_company_invite_state_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invite_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_company_id_companies_id_fk": {
+          "name": "invites_company_id_companies_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_approvals": {
+      "name": "issue_approvals",
+      "schema": "",
+      "columns": {
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_by_agent_id": {
+          "name": "linked_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_by_user_id": {
+          "name": "linked_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_approvals_issue_idx": {
+          "name": "issue_approvals_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_approvals_approval_idx": {
+          "name": "issue_approvals_approval_idx",
+          "columns": [
+            {
+              "expression": "approval_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_approvals_company_idx": {
+          "name": "issue_approvals_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_approvals_company_id_companies_id_fk": {
+          "name": "issue_approvals_company_id_companies_id_fk",
+          "tableFrom": "issue_approvals",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_approvals_issue_id_issues_id_fk": {
+          "name": "issue_approvals_issue_id_issues_id_fk",
+          "tableFrom": "issue_approvals",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_approvals_approval_id_approvals_id_fk": {
+          "name": "issue_approvals_approval_id_approvals_id_fk",
+          "tableFrom": "issue_approvals",
+          "tableTo": "approvals",
+          "columnsFrom": [
+            "approval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_approvals_linked_by_agent_id_agents_id_fk": {
+          "name": "issue_approvals_linked_by_agent_id_agents_id_fk",
+          "tableFrom": "issue_approvals",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "linked_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_approvals_pk": {
+          "name": "issue_approvals_pk",
+          "columns": [
+            "issue_id",
+            "approval_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_attachments": {
+      "name": "issue_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_comment_id": {
+          "name": "issue_comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachments_company_issue_idx": {
+          "name": "issue_attachments_company_issue_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_attachments_issue_comment_idx": {
+          "name": "issue_attachments_issue_comment_idx",
+          "columns": [
+            {
+              "expression": "issue_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_attachments_asset_uq": {
+          "name": "issue_attachments_asset_uq",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachments_company_id_companies_id_fk": {
+          "name": "issue_attachments_company_id_companies_id_fk",
+          "tableFrom": "issue_attachments",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_attachments_issue_id_issues_id_fk": {
+          "name": "issue_attachments_issue_id_issues_id_fk",
+          "tableFrom": "issue_attachments",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_attachments_asset_id_assets_id_fk": {
+          "name": "issue_attachments_asset_id_assets_id_fk",
+          "tableFrom": "issue_attachments",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_attachments_issue_comment_id_issue_comments_id_fk": {
+          "name": "issue_attachments_issue_comment_id_issue_comments_id_fk",
+          "tableFrom": "issue_attachments",
+          "tableTo": "issue_comments",
+          "columnsFrom": [
+            "issue_comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_comments": {
+      "name": "issue_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_agent_id": {
+          "name": "author_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_comments_issue_idx": {
+          "name": "issue_comments_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_comments_company_idx": {
+          "name": "issue_comments_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_comments_company_issue_created_at_idx": {
+          "name": "issue_comments_company_issue_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_comments_company_author_issue_created_at_idx": {
+          "name": "issue_comments_company_author_issue_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_comments_company_id_companies_id_fk": {
+          "name": "issue_comments_company_id_companies_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_comments_issue_id_issues_id_fk": {
+          "name": "issue_comments_issue_id_issues_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_comments_author_agent_id_agents_id_fk": {
+          "name": "issue_comments_author_agent_id_agents_id_fk",
+          "tableFrom": "issue_comments",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "author_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_labels": {
+      "name": "issue_labels",
+      "schema": "",
+      "columns": {
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_labels_issue_idx": {
+          "name": "issue_labels_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_labels_label_idx": {
+          "name": "issue_labels_label_idx",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_labels_company_idx": {
+          "name": "issue_labels_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_labels_issue_id_issues_id_fk": {
+          "name": "issue_labels_issue_id_issues_id_fk",
+          "tableFrom": "issue_labels",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_labels_label_id_labels_id_fk": {
+          "name": "issue_labels_label_id_labels_id_fk",
+          "tableFrom": "issue_labels",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_labels_company_id_companies_id_fk": {
+          "name": "issue_labels_company_id_companies_id_fk",
+          "tableFrom": "issue_labels",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_labels_pk": {
+          "name": "issue_labels_pk",
+          "columns": [
+            "issue_id",
+            "label_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_read_states": {
+      "name": "issue_read_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_read_states_company_issue_idx": {
+          "name": "issue_read_states_company_issue_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_read_states_company_user_idx": {
+          "name": "issue_read_states_company_user_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_read_states_company_issue_user_idx": {
+          "name": "issue_read_states_company_issue_user_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_read_states_company_id_companies_id_fk": {
+          "name": "issue_read_states_company_id_companies_id_fk",
+          "tableFrom": "issue_read_states",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_read_states_issue_id_issues_id_fk": {
+          "name": "issue_read_states_issue_id_issues_id_fk",
+          "tableFrom": "issue_read_states",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'backlog'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "assignee_agent_id": {
+          "name": "assignee_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_user_id": {
+          "name": "assignee_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkout_run_id": {
+          "name": "checkout_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_run_id": {
+          "name": "execution_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_agent_name_key": {
+          "name": "execution_agent_name_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_locked_at": {
+          "name": "execution_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_depth": {
+          "name": "request_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "billing_code": {
+          "name": "billing_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_adapter_overrides": {
+          "name": "assignee_adapter_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_company_status_idx": {
+          "name": "issues_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_company_assignee_status_idx": {
+          "name": "issues_company_assignee_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignee_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_company_assignee_user_status_idx": {
+          "name": "issues_company_assignee_user_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_company_parent_idx": {
+          "name": "issues_company_parent_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_company_project_idx": {
+          "name": "issues_company_project_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issues_identifier_idx": {
+          "name": "issues_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_company_id_companies_id_fk": {
+          "name": "issues_company_id_companies_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_goal_id_goals_id_fk": {
+          "name": "issues_goal_id_goals_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_parent_id_issues_id_fk": {
+          "name": "issues_parent_id_issues_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_assignee_agent_id_agents_id_fk": {
+          "name": "issues_assignee_agent_id_agents_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "assignee_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_checkout_run_id_heartbeat_runs_id_fk": {
+          "name": "issues_checkout_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "checkout_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issues_execution_run_id_heartbeat_runs_id_fk": {
+          "name": "issues_execution_run_id_heartbeat_runs_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "heartbeat_runs",
+          "columnsFrom": [
+            "execution_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issues_created_by_agent_id_agents_id_fk": {
+          "name": "issues_created_by_agent_id_agents_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.join_requests": {
+      "name": "join_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_approval'"
+        },
+        "request_ip": {
+          "name": "request_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requesting_user_id": {
+          "name": "requesting_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_email_snapshot": {
+          "name": "request_email_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_type": {
+          "name": "adapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_defaults_payload": {
+          "name": "agent_defaults_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_secret_hash": {
+          "name": "claim_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_secret_expires_at": {
+          "name": "claim_secret_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_secret_consumed_at": {
+          "name": "claim_secret_consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_agent_id": {
+          "name": "created_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "join_requests_invite_unique_idx": {
+          "name": "join_requests_invite_unique_idx",
+          "columns": [
+            {
+              "expression": "invite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "join_requests_company_status_type_created_idx": {
+          "name": "join_requests_company_status_type_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "join_requests_invite_id_invites_id_fk": {
+          "name": "join_requests_invite_id_invites_id_fk",
+          "tableFrom": "join_requests",
+          "tableTo": "invites",
+          "columnsFrom": [
+            "invite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "join_requests_company_id_companies_id_fk": {
+          "name": "join_requests_company_id_companies_id_fk",
+          "tableFrom": "join_requests",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "join_requests_created_agent_id_agents_id_fk": {
+          "name": "join_requests_created_agent_id_agents_id_fk",
+          "tableFrom": "join_requests",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "created_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labels_company_idx": {
+          "name": "labels_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_company_name_idx": {
+          "name": "labels_company_name_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labels_company_id_companies_id_fk": {
+          "name": "labels_company_id_companies_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principal_permission_grants": {
+      "name": "principal_permission_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_key": {
+          "name": "permission_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principal_permission_grants_unique_idx": {
+          "name": "principal_permission_grants_unique_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principal_permission_grants_company_permission_idx": {
+          "name": "principal_permission_grants_company_permission_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principal_permission_grants_company_id_companies_id_fk": {
+          "name": "principal_permission_grants_company_id_companies_id_fk",
+          "tableFrom": "principal_permission_grants",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_goals": {
+      "name": "project_goals",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_goals_project_idx": {
+          "name": "project_goals_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_goals_goal_idx": {
+          "name": "project_goals_goal_idx",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_goals_company_idx": {
+          "name": "project_goals_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_goals_project_id_projects_id_fk": {
+          "name": "project_goals_project_id_projects_id_fk",
+          "tableFrom": "project_goals",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_goals_goal_id_goals_id_fk": {
+          "name": "project_goals_goal_id_goals_id_fk",
+          "tableFrom": "project_goals",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_goals_company_id_companies_id_fk": {
+          "name": "project_goals_company_id_companies_id_fk",
+          "tableFrom": "project_goals",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_goals_project_id_goal_id_pk": {
+          "name": "project_goals_project_id_goal_id_pk",
+          "columns": [
+            "project_id",
+            "goal_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_workspaces": {
+      "name": "project_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_ref": {
+          "name": "repo_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_workspaces_company_project_idx": {
+          "name": "project_workspaces_company_project_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_workspaces_project_primary_idx": {
+          "name": "project_workspaces_project_primary_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_workspaces_company_id_companies_id_fk": {
+          "name": "project_workspaces_company_id_companies_id_fk",
+          "tableFrom": "project_workspaces",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "project_workspaces_project_id_projects_id_fk": {
+          "name": "project_workspaces_project_id_projects_id_fk",
+          "tableFrom": "project_workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'backlog'"
+        },
+        "lead_agent_id": {
+          "name": "lead_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_key_routing": {
+          "name": "session_key_routing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_company_idx": {
+          "name": "projects_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_company_id_companies_id_fk": {
+          "name": "projects_company_id_companies_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "projects_goal_id_goals_id_fk": {
+          "name": "projects_goal_id_goals_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "projects_lead_agent_id_agents_id_fk": {
+          "name": "projects_lead_agent_id_agents_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "lead_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1773122566562,
       "tag": "0026_green_forge",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1773251018260,
+      "tag": "0027_jazzy_gideon",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/projects.ts
+++ b/packages/db/src/schema/projects.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, date, index } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, date, index, jsonb } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { goals } from "./goals.js";
 import { agents } from "./agents.js";
@@ -15,6 +15,7 @@ export const projects = pgTable(
     leadAgentId: uuid("lead_agent_id").references(() => agents.id),
     targetDate: date("target_date"),
     sessionKey: text("session_key"),
+    sessionKeyRouting: jsonb("session_key_routing"),
     color: text("color"),
     archivedAt: timestamp("archived_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -77,6 +77,7 @@ export type {
   Project,
   ProjectGoalRef,
   ProjectWorkspace,
+  SessionKeyRoutingRule,
   Issue,
   IssueAssigneeAdapterOverrides,
   IssueComment,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -10,7 +10,7 @@ export type {
   AdapterEnvironmentTestResult,
 } from "./agent.js";
 export type { AssetImage } from "./asset.js";
-export type { Project, ProjectGoalRef, ProjectWorkspace } from "./project.js";
+export type { Project, ProjectGoalRef, ProjectWorkspace, SessionKeyRoutingRule } from "./project.js";
 export type {
   Issue,
   IssueAssigneeAdapterOverrides,

--- a/packages/shared/src/types/project.ts
+++ b/packages/shared/src/types/project.ts
@@ -1,5 +1,10 @@
 import type { ProjectStatus } from "../constants.js";
 
+export interface SessionKeyRoutingRule {
+  pattern: string;
+  sessionKey: string;
+}
+
 export interface ProjectGoalRef {
   id: string;
   title: string;
@@ -33,6 +38,7 @@ export interface Project {
   leadAgentId: string | null;
   targetDate: string | null;
   sessionKey: string | null;
+  sessionKeyRouting: SessionKeyRoutingRule[] | null;
   color: string | null;
   workspaces: ProjectWorkspace[];
   primaryWorkspace: ProjectWorkspace | null;

--- a/packages/shared/src/validators/project.ts
+++ b/packages/shared/src/validators/project.ts
@@ -34,8 +34,8 @@ export const updateProjectWorkspaceSchema = z.object({
 export type UpdateProjectWorkspace = z.infer<typeof updateProjectWorkspaceSchema>;
 
 const sessionKeyRoutingRuleSchema = z.object({
-  pattern: z.string().min(1),
-  sessionKey: z.string().min(1),
+  pattern: z.string().trim().min(1),
+  sessionKey: z.string().trim().min(1),
 });
 
 const projectFields = {

--- a/packages/shared/src/validators/project.ts
+++ b/packages/shared/src/validators/project.ts
@@ -33,6 +33,11 @@ export const updateProjectWorkspaceSchema = z.object({
 
 export type UpdateProjectWorkspace = z.infer<typeof updateProjectWorkspaceSchema>;
 
+const sessionKeyRoutingRuleSchema = z.object({
+  pattern: z.string().min(1),
+  sessionKey: z.string().min(1),
+});
+
 const projectFields = {
   /** @deprecated Use goalIds instead */
   goalId: z.string().uuid().optional().nullable(),
@@ -43,6 +48,7 @@ const projectFields = {
   leadAgentId: z.string().uuid().optional().nullable(),
   targetDate: z.string().optional().nullable(),
   sessionKey: z.string().optional().nullable(),
+  sessionKeyRouting: z.array(sessionKeyRoutingRuleSchema).optional().nullable(),
   color: z.string().optional().nullable(),
   archivedAt: z.string().datetime().optional().nullable(),
 };

--- a/server/src/__tests__/heartbeat-project-session-key.test.ts
+++ b/server/src/__tests__/heartbeat-project-session-key.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it } from "vitest";
 import type { Db } from "@paperclipai/db";
-import { enrichContextWithProjectSessionKey } from "../services/heartbeat.ts";
+import { enrichContextWithProjectRouting, enrichContextWithProjectSessionKey } from "../services/heartbeat.ts";
 
-function mockDbWithSessionKey(sessionKey: string | null): Db {
+function mockDbProjectRow(projectRow: { sessionKey: string | null; sessionKeyRouting?: unknown }): Db {
   return {
     select: () => ({
       from: () => ({
         where: () =>
           Promise.resolve([
             {
-              sessionKey,
+              sessionKey: projectRow.sessionKey,
+              sessionKeyRouting: projectRow.sessionKeyRouting ?? null,
             },
           ]),
       }),
@@ -24,12 +25,60 @@ describe("enrichContextWithProjectSessionKey", () => {
     };
 
     const resolved = await enrichContextWithProjectSessionKey({
-      db: mockDbWithSessionKey("paperclip:project:alpha"),
+      db: mockDbProjectRow({ sessionKey: "paperclip:project:alpha" }),
       companyId: "company-123",
       context,
     });
 
     expect(resolved).toBe("paperclip:project:alpha");
     expect(context.projectSessionKey).toBe("paperclip:project:alpha");
+  });
+});
+
+describe("enrichContextWithProjectRouting", () => {
+  it("adds projectSessionKeyRouting to context when the resolved project has valid routing rules", async () => {
+    const context: Record<string, unknown> = {
+      projectId: "project-123",
+    };
+
+    const resolved = await enrichContextWithProjectRouting({
+      db: mockDbProjectRow({
+        sessionKey: null,
+        sessionKeyRouting: [{ pattern: "assignment:*", sessionKey: "{{projectSessionKey}}" }],
+      }),
+      companyId: "company-123",
+      context,
+    });
+
+    expect(resolved).toEqual([{ pattern: "assignment:*", sessionKey: "{{projectSessionKey}}" }]);
+    expect(context.projectSessionKeyRouting).toEqual([
+      { pattern: "assignment:*", sessionKey: "{{projectSessionKey}}" },
+    ]);
+  });
+
+  it("falls through when project routing is null or empty", async () => {
+    const withNull: Record<string, unknown> = {
+      projectId: "project-123",
+      projectSessionKeyRouting: [{ pattern: "*", sessionKey: "stale" }],
+    };
+    const resolvedNull = await enrichContextWithProjectRouting({
+      db: mockDbProjectRow({ sessionKey: null, sessionKeyRouting: null }),
+      companyId: "company-123",
+      context: withNull,
+    });
+    expect(resolvedNull).toBeNull();
+    expect(withNull.projectSessionKeyRouting).toBeUndefined();
+
+    const withEmpty: Record<string, unknown> = {
+      projectId: "project-123",
+      projectSessionKeyRouting: [{ pattern: "*", sessionKey: "stale" }],
+    };
+    const resolvedEmpty = await enrichContextWithProjectRouting({
+      db: mockDbProjectRow({ sessionKey: null, sessionKeyRouting: [] }),
+      companyId: "company-123",
+      context: withEmpty,
+    });
+    expect(resolvedEmpty).toBeNull();
+    expect(withEmpty.projectSessionKeyRouting).toBeUndefined();
   });
 });

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -447,7 +447,7 @@ describe("openclaw gateway adapter execute", () => {
     expect(result.errorCode).toBe("openclaw_gateway_url_missing");
   });
 
-  it("prefers project session key over strategy-derived session key", async () => {
+  it("uses strategy-derived session key when no routing rule matches projectSessionKey", async () => {
     const gateway = await createMockGatewayServer();
 
     try {
@@ -475,13 +475,13 @@ describe("openclaw gateway adapter execute", () => {
       expect(result.exitCode).toBe(0);
       const payload = gateway.getAgentPayload();
       expect(payload).toBeTruthy();
-      expect(payload?.sessionKey).toBe("paperclip:project:alpha");
+      expect(payload?.sessionKey).toBe("paperclip:run:run-123");
     } finally {
       await gateway.close();
     }
   });
 
-  it("falls back to strategy-derived session key when project session key is null", async () => {
+  it("resolves projectSessionKey through routing templates when configured", async () => {
     const gateway = await createMockGatewayServer();
 
     try {
@@ -492,15 +492,18 @@ describe("openclaw gateway adapter execute", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
-            sessionKeyStrategy: "run",
+            sessionKeyRouting: [
+              { pattern: "assignment:*", sessionKey: "{{projectSessionKey}}" },
+            ],
           },
           {
             context: {
               taskId: "task-123",
               issueId: "issue-123",
+              wakeSource: "assignment",
               wakeReason: "issue_assigned",
               issueIds: ["issue-123"],
-              projectSessionKey: null,
+              projectSessionKey: "paperclip:project:alpha",
             },
           },
         ),
@@ -509,7 +512,7 @@ describe("openclaw gateway adapter execute", () => {
       expect(result.exitCode).toBe(0);
       const payload = gateway.getAgentPayload();
       expect(payload).toBeTruthy();
-      expect(payload?.sessionKey).toBe("paperclip:run:run-123");
+      expect(payload?.sessionKey).toBe("paperclip:project:alpha");
     } finally {
       await gateway.close();
     }

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -732,4 +732,60 @@ describe("openclaw gateway session key routing helpers", () => {
     });
     expect(fromFallback).toBe("paperclip:run:run-1");
   });
+
+  it("prioritizes project routing rules before agent routing rules", () => {
+    const resolved = resolveSessionKeyFromRouting({
+      projectRoutingRules: [{ pattern: "assignment:*", sessionKey: "project:{{projectId}}" }],
+      routingRules: [{ pattern: "assignment:*", sessionKey: "agent:{{agentId}}" }],
+      wakeSource: "assignment",
+      wakeReason: "issue_assigned",
+      runId: "run-1",
+      issueId: "issue-1",
+      projectId: "project-1",
+      projectSessionKey: "paperclip:project:alpha",
+      agentId: "agent-1",
+      fallback: {
+        strategy: "run",
+        configuredSessionKey: null,
+      },
+    });
+
+    expect(resolved).toBe("project:project-1");
+  });
+
+  it("falls through to agent routing rules when project routing rules are null or empty", () => {
+    const fromEmptyProjectRules = resolveSessionKeyFromRouting({
+      projectRoutingRules: [],
+      routingRules: [{ pattern: "assignment:*", sessionKey: "agent:{{agentId}}" }],
+      wakeSource: "assignment",
+      wakeReason: "issue_assigned",
+      runId: "run-1",
+      issueId: "issue-1",
+      projectId: "project-1",
+      projectSessionKey: "paperclip:project:alpha",
+      agentId: "agent-1",
+      fallback: {
+        strategy: "fixed",
+        configuredSessionKey: "paperclip",
+      },
+    });
+    expect(fromEmptyProjectRules).toBe("agent:agent-1");
+
+    const fromNullProjectRules = resolveSessionKeyFromRouting({
+      projectRoutingRules: null,
+      routingRules: [{ pattern: "assignment:*", sessionKey: "agent:{{agentId}}" }],
+      wakeSource: "assignment",
+      wakeReason: "issue_assigned",
+      runId: "run-1",
+      issueId: "issue-1",
+      projectId: "project-1",
+      projectSessionKey: "paperclip:project:alpha",
+      agentId: "agent-1",
+      fallback: {
+        strategy: "fixed",
+        configuredSessionKey: "paperclip",
+      },
+    });
+    expect(fromNullProjectRules).toBe("agent:agent-1");
+  });
 });

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { createServer } from "node:http";
 import { WebSocketServer } from "ws";
-import { execute, testEnvironment } from "@paperclipai/adapter-openclaw-gateway/server";
+import {
+  execute,
+  interpolateTemplate,
+  matchPattern,
+  resolveSessionKeyFromRouting,
+  testEnvironment,
+} from "@paperclipai/adapter-openclaw-gateway/server";
 import { parseOpenClawGatewayStdoutLine } from "@paperclipai/adapter-openclaw-gateway/ui";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
 
@@ -509,6 +515,117 @@ describe("openclaw gateway adapter execute", () => {
     }
   });
 
+  it("uses first routing rule match when template resolves", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext(
+          {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            sessionKeyStrategy: "run",
+            sessionKeyRouting: [
+              { pattern: "assignment:*", sessionKey: "route:assignment" },
+              { pattern: "*", sessionKey: "route:fallback" },
+            ],
+          },
+          {
+            context: {
+              taskId: "task-123",
+              issueId: "issue-123",
+              wakeSource: "assignment",
+              wakeReason: "issue_assigned",
+              issueIds: ["issue-123"],
+            },
+          },
+        ),
+      );
+
+      expect(result.exitCode).toBe(0);
+      const payload = gateway.getAgentPayload();
+      expect(payload).toBeTruthy();
+      expect(payload?.sessionKey).toBe("route:assignment");
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("skips routing rules with unresolvable templates and uses next rule", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext(
+          {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            sessionKeyRouting: [
+              { pattern: "assignment:*", sessionKey: "{{projectSessionKey}}" },
+              { pattern: "assignment:*", sessionKey: "route:{{issueId}}" },
+            ],
+          },
+          {
+            context: {
+              taskId: "task-123",
+              issueId: "issue-123",
+              wakeSource: "assignment",
+              wakeReason: "issue_assigned",
+              issueIds: ["issue-123"],
+              projectSessionKey: null,
+            },
+          },
+        ),
+      );
+
+      expect(result.exitCode).toBe(0);
+      const payload = gateway.getAgentPayload();
+      expect(payload).toBeTruthy();
+      expect(payload?.sessionKey).toBe("route:issue-123");
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("falls back to legacy strategy when routing rules do not resolve", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext(
+          {
+            url: gateway.url,
+            headers: {
+              "x-openclaw-token": "gateway-token",
+            },
+            sessionKeyStrategy: "run",
+            sessionKeyRouting: [{ pattern: "timer:*", sessionKey: "route:timer" }],
+          },
+          {
+            context: {
+              taskId: "task-123",
+              issueId: "issue-123",
+              wakeSource: "assignment",
+              wakeReason: "issue_assigned",
+              issueIds: ["issue-123"],
+            },
+          },
+        ),
+      );
+
+      expect(result.exitCode).toBe(0);
+      const payload = gateway.getAgentPayload();
+      expect(payload).toBeTruthy();
+      expect(payload?.sessionKey).toBe("paperclip:run:run-123");
+    } finally {
+      await gateway.close();
+    }
+  });
+
   it("auto-approves pairing once and retries the run", async () => {
     const gateway = await createMockGatewayServerWithPairing();
     const logs: string[] = [];
@@ -557,5 +674,62 @@ describe("openclaw gateway testEnvironment", () => {
 
     expect(result.status).toBe("fail");
     expect(result.checks.some((check) => check.code === "openclaw_gateway_url_missing")).toBe(true);
+  });
+});
+
+describe("openclaw gateway session key routing helpers", () => {
+  it("matches exact, wildcard, source wildcard, reason wildcard, and prefix glob patterns", () => {
+    expect(matchPattern("assignment:issue_assigned", "assignment:issue_assigned")).toBe(true);
+    expect(matchPattern("assignment:issue_assigned", "*")).toBe(true);
+    expect(matchPattern("assignment:issue_assigned", "assignment:*")).toBe(true);
+    expect(matchPattern("assignment:issue_assigned", "*:issue_assigned")).toBe(true);
+    expect(matchPattern("automation:issue_created", "automation:issue_*")).toBe(true);
+    expect(matchPattern("automation:manual", "automation:issue_*")).toBe(false);
+  });
+
+  it("interpolates templates from context variables and returns null when unresolved", () => {
+    expect(interpolateTemplate("route:{{agentId}}:{{runId}}", { agentId: "agent-1", runId: "run-1" })).toBe(
+      "route:agent-1:run-1",
+    );
+    expect(interpolateTemplate("route:{{projectSessionKey}}", { projectSessionKey: null })).toBeNull();
+    expect(interpolateTemplate("route:{{wakeSource}}", { wakeSource: "" })).toBeNull();
+  });
+
+  it("evaluates rules in order, skips unresolvable templates, and falls back", () => {
+    const fromRouting = resolveSessionKeyFromRouting({
+      routingRules: [
+        { pattern: "assignment:*", sessionKey: "{{projectSessionKey}}" },
+        { pattern: "assignment:*", sessionKey: "route:{{issueId}}" },
+        { pattern: "*", sessionKey: "route:fallback" },
+      ],
+      wakeSource: "assignment",
+      wakeReason: "issue_assigned",
+      runId: "run-1",
+      issueId: "issue-1",
+      projectId: null,
+      projectSessionKey: null,
+      agentId: "agent-1",
+      fallback: {
+        strategy: "run",
+        configuredSessionKey: null,
+      },
+    });
+    expect(fromRouting).toBe("route:issue-1");
+
+    const fromFallback = resolveSessionKeyFromRouting({
+      routingRules: [{ pattern: "timer:*", sessionKey: "route:timer" }],
+      wakeSource: "assignment",
+      wakeReason: "issue_assigned",
+      runId: "run-1",
+      issueId: "issue-1",
+      projectId: null,
+      projectSessionKey: null,
+      agentId: "agent-1",
+      fallback: {
+        strategy: "run",
+        configuredSessionKey: null,
+      },
+    });
+    expect(fromFallback).toBe("paperclip:run:run-1");
   });
 });

--- a/server/src/__tests__/project-validator-session-key.test.ts
+++ b/server/src/__tests__/project-validator-session-key.test.ts
@@ -21,6 +21,38 @@ describe("project schema sessionKey contract", () => {
     expect(omitted.sessionKey).toBeUndefined();
   });
 
+  it("accepts array, null, and omitted sessionKeyRouting for create/update", () => {
+    const rules = [{ pattern: "assignment:*", sessionKey: "{{projectSessionKey}}" }];
+
+    const createWithRules = createProjectSchema.parse({
+      name: "Core Platform",
+      sessionKeyRouting: rules,
+    });
+    expect(createWithRules.sessionKeyRouting).toEqual(rules);
+
+    const createWithNull = createProjectSchema.parse({
+      name: "Core Platform",
+      sessionKeyRouting: null,
+    });
+    expect(createWithNull.sessionKeyRouting).toBeNull();
+
+    const createOmitted = createProjectSchema.parse({ name: "Core Platform" });
+    expect(createOmitted.sessionKeyRouting).toBeUndefined();
+
+    const updateWithRules = updateProjectSchema.parse({
+      sessionKeyRouting: rules,
+    });
+    expect(updateWithRules.sessionKeyRouting).toEqual(rules);
+
+    const updateWithNull = updateProjectSchema.parse({
+      sessionKeyRouting: null,
+    });
+    expect(updateWithNull.sessionKeyRouting).toBeNull();
+
+    const updateOmitted = updateProjectSchema.parse({});
+    expect(updateOmitted.sessionKeyRouting).toBeUndefined();
+  });
+
   it("accepts string, null, and omitted sessionKey for update", () => {
     const withString = updateProjectSchema.parse({
       sessionKey: "paperclip:core-platform",
@@ -47,6 +79,21 @@ describe("project schema sessionKey contract", () => {
     expect(() =>
       updateProjectSchema.parse({
         sessionKey: { value: "paperclip:core-platform" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid sessionKeyRouting shapes", () => {
+    expect(() =>
+      createProjectSchema.parse({
+        name: "Core Platform",
+        sessionKeyRouting: [{ pattern: "assignment:*" }],
+      }),
+    ).toThrow();
+
+    expect(() =>
+      updateProjectSchema.parse({
+        sessionKeyRouting: [{ pattern: "", sessionKey: "route" }],
       }),
     ).toThrow();
   });

--- a/server/src/__tests__/project-validator-session-key.test.ts
+++ b/server/src/__tests__/project-validator-session-key.test.ts
@@ -96,5 +96,17 @@ describe("project schema sessionKey contract", () => {
         sessionKeyRouting: [{ pattern: "", sessionKey: "route" }],
       }),
     ).toThrow();
+
+    expect(() =>
+      updateProjectSchema.parse({
+        sessionKeyRouting: [{ pattern: "   ", sessionKey: "route" }],
+      }),
+    ).toThrow();
+
+    expect(() =>
+      updateProjectSchema.parse({
+        sessionKeyRouting: [{ pattern: "assignment:*", sessionKey: "   " }],
+      }),
+    ).toThrow();
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -75,6 +75,11 @@ interface ParsedIssueAssigneeAdapterOverrides {
   useProjectWorkspace: boolean | null;
 }
 
+type SessionKeyRoutingRule = {
+  pattern: string;
+  sessionKey: string;
+};
+
 export type ResolvedWorkspaceForRun = {
   cwd: string;
   source: "project_primary" | "task_session" | "agent_home";
@@ -347,6 +352,17 @@ function normalizeSessionParams(params: Record<string, unknown> | null | undefin
   return Object.keys(params).length > 0 ? params : null;
 }
 
+function parseSessionKeyRouting(value: unknown): SessionKeyRoutingRule[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => parseObject(entry))
+    .map((entry) => ({
+      pattern: readNonEmptyString(entry.pattern),
+      sessionKey: readNonEmptyString(entry.sessionKey),
+    }))
+    .filter((entry): entry is SessionKeyRoutingRule => Boolean(entry.pattern && entry.sessionKey));
+}
+
 export async function enrichContextWithProjectSessionKey(input: {
   db: Db;
   companyId: string;
@@ -370,6 +386,32 @@ export async function enrichContextWithProjectSessionKey(input: {
   }
 
   delete input.context.projectSessionKey;
+  return null;
+}
+
+export async function enrichContextWithProjectRouting(input: {
+  db: Db;
+  companyId: string;
+  context: Record<string, unknown>;
+}) {
+  const projectId = readNonEmptyString(input.context.projectId);
+  if (!projectId) {
+    delete input.context.projectSessionKeyRouting;
+    return null;
+  }
+
+  const projectSessionKeyRouting = await input.db
+    .select({ sessionKeyRouting: projects.sessionKeyRouting })
+    .from(projects)
+    .where(and(eq(projects.id, projectId), eq(projects.companyId, input.companyId)))
+    .then((rows) => parseSessionKeyRouting(rows[0]?.sessionKeyRouting));
+
+  if (projectSessionKeyRouting.length > 0) {
+    input.context.projectSessionKeyRouting = projectSessionKeyRouting;
+    return projectSessionKeyRouting;
+  }
+
+  delete input.context.projectSessionKeyRouting;
   return null;
 }
 
@@ -1156,6 +1198,11 @@ export function heartbeatService(db: Db) {
       context.projectId = resolvedWorkspace.projectId;
     }
     await enrichContextWithProjectSessionKey({
+      db,
+      companyId: agent.companyId,
+      context,
+    });
+    await enrichContextWithProjectRouting({
       db,
       companyId: agent.companyId,
       context,

--- a/session-key-routing.md
+++ b/session-key-routing.md
@@ -1,0 +1,313 @@
+---
+shaping: true
+---
+
+# Session Key Routing Table — Shaping
+
+**Issue:** [ghostwater-ai/paperclip#9](https://github.com/ghostwater-ai/paperclip/issues/9)
+
+---
+
+## Source
+
+> Okay so we need to make sure:
+> 1. The info available at the time of the event is sufficient to rebuild the full key
+> 2. paperclip's open claw adapter uses it correctly to create the right key
+> Effectively we need a way to customize session mapping for events. For example, I might want heartbeats in one session, issue updates in a per project per agent session, etc
+>
+> — James, 2026-03-11
+
+> Okay but sometimes the dynamic value won't be one of those. It could be a slack channel id corresponding to the project
+>
+> — James, 2026-03-11
+
+---
+
+## Problem
+
+The OpenClaw Gateway adapter resolves a single session key per agent via a strategy enum (`fixed`/`issue`/`run`), with a project-level override (PR #8). Users can't route different event types to different OpenClaw sessions. All heartbeats, issue updates, assignments, and on-demand triggers for an agent land in the same session — or the project override takes all of them.
+
+Real need: heartbeats in a dedicated session, issue work in a project-specific Slack channel, assignments elsewhere. The dynamic values aren't always Paperclip-internal IDs — they can be arbitrary user-defined strings like Slack channel IDs stored on the project.
+
+---
+
+## Outcome
+
+An agent's OpenClaw adapter can route different event types to different sessions using a configurable mapping, with template variables that resolve from event context including user-defined project fields.
+
+---
+
+## CURRENT System
+
+| Part | Mechanism |
+|------|-----------|
+| **CUR1** | **Session key strategy** — `sessionKeyStrategy` enum on adapter config: `fixed` (default "paperclip"), `issue` (per-issue key), `run` (per-run key) |
+| **CUR2** | **Project session key override** — `sessionKey` text column on `projects` table. When set, takes top priority over strategy in `resolveSessionKey()` |
+| **CUR3** | **Resolution order** — `resolveSessionKey()`: project key → strategy-based key → fallback "paperclip" |
+| **CUR4** | **Context enrichment** — `enrichWakeContextSnapshot()` in heartbeat.ts populates: `wakeReason`, `wakeSource`, `issueId`, `taskId`, `taskKey`, `commentId`, `projectId` |
+| **CUR5** | **OpenClaw canonicalization** — OpenClaw prepends `agent:<configDefault>:` to bare session keys. "paperclip" → "agent:main:paperclip" |
+
+### Context available at adapter execute time
+
+| Field | Source | Present when |
+|-------|--------|-------------|
+| `context.wakeReason` | enrichWakeContextSnapshot | Always (set from `reason` param) |
+| `context.wakeSource` | enrichWakeContextSnapshot | Always (set from `source` param) |
+| `context.projectId` | workspace resolution | Event is project-scoped |
+| `context.projectSessionKey` | PR #8 enrichment | Project has `sessionKey` set |
+| `context.issueId` | enrichWakeContextSnapshot | Event involves an issue |
+| `context.taskId` | enrichWakeContextSnapshot | Event involves an issue (mirrors issueId) |
+| `context.taskKey` | enrichWakeContextSnapshot | Issue has a task key |
+| `ctx.runId` | Always present | Always |
+| `ctx.agent.id` | Always present | Always |
+| `ctx.config.agentId` | Adapter config | When user configured OpenClaw agent ID |
+
+### Known wake reasons
+
+| Source | Reasons |
+|--------|---------|
+| `timer` | `heartbeat_timer`, `interval_elapsed` |
+| `assignment` | `issue_assigned` |
+| `automation` | `issue_created`, `issue_updated`, `issue_execution_promoted`, `issue_execution_issue_not_found`, `issue_execution_same_name`, `issue_execution_deferred` |
+| `on_demand` | `manual`, `ping`, `callback`, `system` |
+
+---
+
+## Requirements (R)
+
+| ID | Requirement | Status |
+|----|-------------|--------|
+| R0 | Route different event types to different OpenClaw sessions | Core goal |
+| R1 | Template variables resolve from event context (wakeSource, wakeReason, projectId, issueId, runId, agentId) | Must-have |
+| R2 | Support user-defined dynamic values (e.g. Slack channel ID stored on project) | Must-have |
+| R3 | Backward compatible — no routing config = current behavior | Must-have |
+| R4 | Configurable per agent through UI (list editor + JSON escape hatch) | Must-have |
+| R5 | Unresolvable template variables produce a sensible fallback, not a broken key | Must-have |
+| R6 | OpenClaw canonicalization (`agent:<default>:<key>`) continues to work correctly | Must-have |
+| R7 | Glob pattern syntax with prefix matching (e.g. `automation:issue_*`) | Must-have |
+| R8 | CLI support via `--adapter-config-file` (JSON file with routing rules) | Must-have |
+| R9 | Projects can define their own routing rules that override agent-level table | Must-have |
+
+---
+
+## Shape A: Routing Table with Pattern Matching
+
+Session key routing is a list of rules evaluated in order. Each rule has a **pattern** (matching `source:reason`) and a **template** (the session key to produce, with `{{variable}}` interpolation).
+
+| Part | Mechanism | Flag |
+|------|-----------|:----:|
+| **A1** | **Routing rule schema** — ordered array of `{ pattern: string, sessionKey: string }` in adapter config. Pattern is `source:reason` with `*` wildcard support (e.g. `timer:*`, `*:issue_created`, `*`). Template supports `{{var}}` interpolation. | |
+| **A2** | **Template variable resolution** — resolver function takes event context and produces a flat `Record<string, string>` of available variables: `agentId`, `projectId`, `projectSessionKey`, `issueId`, `runId`, `wakeSource`, `wakeReason` | |
+| **A3** | **Evaluation logic** — `resolveSessionKey()` replaced: iterate rules in order, first matching pattern wins. Interpolate template variables. If a referenced variable is empty, skip this rule and try next. Final fallback: current strategy-based logic (backward compat). | |
+| **A4** | **UI — list editor + JSON toggle** — `RoutingRulesEditor` React component in openclaw-gateway config-fields.tsx. Each row: pattern input + session key template input. Add/remove/reorder. "Edit as JSON" toggle for power users. Wired via `mark("adapterConfig", "sessionKeyRouting", rules)`. | |
+| **A5** | **Project sessionKey becomes template-only** — `projectSessionKey` no longer overrides at top priority in `resolveSessionKey()`. Instead available as `{{projectSessionKey}}` in templates. Rules that use it only fire when a project is in context AND has a sessionKey set. | |
+| **A6** | **Per-project routing rules** — `projects` table gets a `sessionKeyRouting` JSON column (same schema as agent-level rules). Project `sessionKey` stays as the data source for `{{projectSessionKey}}`. When a project has routing rules AND the event is project-scoped, project rules are evaluated first. If no project rule matches, fall through to agent-level rules. UI: reuse `RoutingRulesEditor` in Project Properties + New Project dialog. | |
+| **A7** | **CLI support** — `paperclipai agent update --adapter-config-file config.json` already works for flat config. Routing rules are part of adapter config, so they come along for free. Document the JSON schema for routing rules in the config file. | | |
+
+### Example configuration
+
+```
+Rules (evaluated top to bottom):
+1. timer:heartbeat_timer  →  heartbeat
+2. timer:interval_elapsed →  heartbeat
+3. assignment:*           →  {{projectSessionKey}}
+4. automation:issue_*     →  {{projectSessionKey}}
+5. *                      →  paperclip
+```
+
+With project sessionKey = `slack:channel:c0ag0u06yka`:
+- Heartbeat → `heartbeat` → OpenClaw: `agent:main:heartbeat`
+- Issue assigned to project → `slack:channel:c0ag0u06yka` → OpenClaw: `agent:main:slack:channel:c0ag0u06yka`
+- Manual trigger without project → skips rules 3-4 (unresolvable), hits rule 5 → `paperclip`
+
+### Pattern matching (glob)
+
+Patterns use `source:reason` format with glob-style `*` wildcard:
+- `*` alone matches everything
+- `timer:*` matches any reason with source "timer"
+- `*:issue_created` matches any source with reason "issue_created"
+- `automation:issue_*` matches reasons starting with "issue_" under source "automation"
+- Exact match: `timer:heartbeat_timer` matches only that combination
+
+### Skip-on-unresolvable behavior
+
+When a template references `{{projectSessionKey}}` but the event has no project or the project has no sessionKey, the rule is **skipped** and evaluation continues to the next rule. This means:
+- Rules with dynamic variables are self-gating — they only fire when the data exists
+- The fallback rule (`*` → `paperclip`) catches everything else
+- No broken keys ever reach OpenClaw
+
+### Per-project routing rules
+
+Projects can define their own routing rules (same schema). Resolution order:
+1. If event is project-scoped AND project has routing rules → evaluate project rules
+2. If no project rule matches (or no project rules) → evaluate agent-level rules
+3. If no agent rule matches → current strategy-based fallback
+
+This means a project can say "my issue events go to `slack:channel:c0ag0u06yka`" without affecting other projects or non-project events.
+
+---
+
+## Fit Check
+
+| Req | Requirement | Status | A |
+|-----|-------------|--------|---|
+| R0 | Route different event types to different OpenClaw sessions | Core goal | ✅ |
+| R1 | Template variables resolve from event context | Must-have | ✅ |
+| R2 | Support user-defined dynamic values (e.g. Slack channel ID on project) | Must-have | ✅ |
+| R3 | Backward compatible — no routing config = current behavior | Must-have | ✅ |
+| R4 | Configurable per agent through UI (list editor + JSON escape hatch) | Must-have | ✅ |
+| R5 | Unresolvable template variables produce sensible fallback | Must-have | ✅ |
+| R6 | OpenClaw canonicalization continues to work | Must-have | ✅ |
+| R7 | Glob pattern syntax with prefix matching | Must-have | ✅ |
+| R8 | CLI support via --adapter-config-file | Must-have | ✅ |
+| R9 | Projects can define their own routing rules | Must-have | ✅ |
+
+**Notes:**
+- All requirements pass. No flagged unknowns remain.
+
+---
+
+---
+
+## Breadboard
+
+### Places
+
+| # | Place | Description |
+|---|-------|-------------|
+| P1 | Agent Config — OpenClaw Gateway | Adapter config panel in agent settings |
+| P2 | New Project Dialog | Modal for creating a new project |
+| P3 | Project Properties | Panel for editing project settings |
+| P4 | Backend — Server | Heartbeat service + adapter execution |
+
+### UI Affordances
+
+| # | Place | Component | Affordance | Control | Wires Out | Returns To |
+|---|-------|-----------|------------|---------|-----------|------------|
+| U1 | P1 | config-fields | Session strategy select | select | → N1 | — |
+| U2 | P1 | config-fields | Session key input (fixed) | type | → N1 | — |
+| U3 | P1 | RoutingRulesEditor | Rules list (rows of pattern + template) | render | — | — |
+| U4 | P1 | RoutingRulesEditor | Add rule button | click | → N2 | — |
+| U5 | P1 | RoutingRulesEditor | Remove rule button | click | → N3 | — |
+| U6 | P1 | RoutingRulesEditor | Reorder handle (drag) | drag | → N4 | — |
+| U7 | P1 | RoutingRulesEditor | Pattern input per row | type | → N5 | — |
+| U8 | P1 | RoutingRulesEditor | Session key template input per row | type | → N5 | — |
+| U9 | P1 | RoutingRulesEditor | "Edit as JSON" toggle | click | → N6 | — |
+| U10 | P1 | RoutingRulesEditor | JSON textarea (when toggled) | type | → N7 | — |
+| U11 | P2 | NewProjectDialog | Session key input | type | — | — |
+| U12 | P2 | RoutingRulesEditor | Project routing rules (same component) | render | — | — |
+| U13 | P3 | ProjectProperties | Session key input | type | → N8 | — |
+| U14 | P3 | RoutingRulesEditor | Project routing rules (same component) | render | — | — |
+
+### Code Affordances
+
+| # | Place | Component | Affordance | Control | Wires Out | Returns To |
+|---|-------|-----------|------------|---------|-----------|------------|
+| N1 | P1 | config-fields | `mark("adapterConfig", "sessionKeyRouting", rules)` | call | — | → U3 |
+| N2 | P1 | RoutingRulesEditor | append empty rule to array | call | — | → U3 |
+| N3 | P1 | RoutingRulesEditor | splice rule from array | call | — | → U3 |
+| N4 | P1 | RoutingRulesEditor | reorder array | call | — | → U3 |
+| N5 | P1 | RoutingRulesEditor | update rule field in array | call | — | → U3 |
+| N6 | P1 | RoutingRulesEditor | toggle JSON/list mode | call | — | → U3, → U10 |
+| N7 | P1 | RoutingRulesEditor | parse JSON, validate, update rules | call | — | → U3 |
+| N8 | P3 | ProjectProperties | `onUpdate({ sessionKey })` | call | — | — |
+| N9 | P4 | heartbeat.ts | `enrichContextWithProjectSessionKey()` | call | → S2 | → N11 |
+| N10 | P4 | heartbeat.ts | `enrichContextWithProjectRouting()` | call | → S3 | → N11 |
+| N11 | P4 | execute.ts | `resolveSessionKeyFromRouting()` | call | → N12 | → S4 |
+| N12 | P4 | execute.ts | `matchPattern(source:reason, pattern)` | call | — | → N11 |
+| N13 | P4 | execute.ts | `interpolateTemplate(template, vars)` | call | — | → N11 |
+| N14 | P4 | execute.ts | `resolveSessionKey()` (existing fallback) | call | — | → S4 |
+
+### Data Stores
+
+| # | Place | Store | Description |
+|---|-------|-------|-------------|
+| S1 | P4 | `adapterConfig.sessionKeyRouting` | Agent-level routing rules (JSON in adapter config) |
+| S2 | P4 | `projects.sessionKey` | Per-project session key value (existing from PR #8) |
+| S3 | P4 | `projects.sessionKeyRouting` | Per-project routing rules (new JSON column) |
+| S4 | P4 | resolved `sessionKey` | Final session key sent in WebSocket payload |
+| S5 | P4 | `context.*` | Template variable bag: wakeSource, wakeReason, projectId, issueId, runId, agentId, projectSessionKey |
+
+### Wiring Narrative
+
+**Agent config (P1):** User configures routing rules via list editor or JSON toggle. Rules are stored as `sessionKeyRouting` in adapter config alongside existing `sessionKeyStrategy` and `sessionKey`. Both systems coexist — rules take priority when present, strategy is the fallback.
+
+**Project config (P2/P3):** User sets a `sessionKey` value (data, e.g. Slack channel ID) and optionally defines per-project routing rules. Both stored on the project.
+
+**Runtime resolution (P4):** On each wake event:
+1. `enrichContextWithProjectSessionKey()` loads project's `sessionKey` → available as `{{projectSessionKey}}`
+2. `enrichContextWithProjectRouting()` loads project's `sessionKeyRouting` rules (NEW)
+3. `resolveSessionKeyFromRouting()` evaluates: project rules first → agent rules → existing strategy fallback
+4. For each rule: `matchPattern()` checks `source:reason` against glob pattern. If match, `interpolateTemplate()` resolves `{{vars}}`. If any var unresolvable, skip rule and try next.
+5. Final `sessionKey` goes into WebSocket payload.
+
+---
+
+## Slices
+
+| # | Slice | Mechanism | Demo |
+|---|-------|-----------|------|
+| V1 | Routing engine | A1-A3: schema, variable resolver, evaluation logic | "Configure rules in DB, heartbeat routes to correct session" |
+| V2 | Agent config UI | A4: RoutingRulesEditor component | "Add/edit/reorder rules in agent config panel, toggle JSON view" |
+| V3 | Per-project routing | A5-A6: project routing rules + sessionKey as template var | "Project with rules overrides agent routing for its events" |
+| V4 | Project UI | A6: routing rules in project dialogs | "Configure project routing rules in New Project + Properties" |
+
+### V1: Routing Engine (backend)
+
+| # | Affordance | Notes |
+|---|------------|-------|
+| N11 | `resolveSessionKeyFromRouting()` | New function, replaces direct `resolveSessionKey()` call |
+| N12 | `matchPattern()` | Glob matching: `*`, `source:*`, `automation:issue_*` |
+| N13 | `interpolateTemplate()` | `{{var}}` replacement, returns null if any var missing |
+| N14 | `resolveSessionKey()` | Existing — becomes inner fallback |
+| S1 | `adapterConfig.sessionKeyRouting` | Read from adapter config |
+| S5 | `context.*` | Template variable bag |
+
+**Demo:** Set `sessionKeyRouting` directly in adapter config JSON. Fire heartbeat → routes to `heartbeat` session. Fire issue event → routes to `project-channel` session. No rules → falls back to existing strategy.
+
+### V2: Agent Config UI
+
+| # | Affordance | Notes |
+|---|------------|-------|
+| U3-U10 | RoutingRulesEditor | New reusable component |
+| N1-N7 | Editor state management | Array manipulation + JSON toggle |
+
+**Demo:** Open agent config, see routing rules editor below session strategy. Add rules, reorder, edit patterns/templates. Toggle to JSON view, edit raw, toggle back. Save — rules persist.
+
+### V3: Per-Project Routing (backend)
+
+| # | Affordance | Notes |
+|---|------------|-------|
+| N10 | `enrichContextWithProjectRouting()` | New — loads project rules into context |
+| S3 | `projects.sessionKeyRouting` | New JSON column + migration |
+
+**Demo:** Set project routing rules via DB. Fire project-scoped event → project rules win. Fire non-project event → agent rules used. Project with no rules → falls through to agent rules.
+
+### V4: Project UI
+
+| # | Affordance | Notes |
+|---|------------|-------|
+| U12 | RoutingRulesEditor in NewProjectDialog | Reuses V2 component |
+| U14 | RoutingRulesEditor in ProjectProperties | Reuses V2 component |
+
+**Demo:** Open project properties, see routing rules editor below session key field. Add project-specific rules. Create new project with routing rules.
+
+---
+
+## Decisions Made
+
+| # | Question | Decision |
+|---|----------|----------|
+| Q1 | Rule editing UI | **(c)** List editor + "edit as JSON" toggle |
+| Q2 | Pattern syntax | **(b)** Glob with prefix matching (`automation:issue_*`) |
+| Q3 | CLI support | **(a)** Via `--adapter-config-file` (JSON file) |
+| Q4 | Per-project routing | **(b)** Projects can define their own routing rules |
+| Q5 | Scope | **(a)** Session key routing only (message templates separate) |
+
+## Open Questions
+
+1. ~~**A4 spike needed**~~ **Resolved:** Config fields are plain React components per adapter — no framework/schema system to extend. `OpenClawGatewayConfigFields` in `ui/src/adapters/openclaw-gateway/config-fields.tsx` is a regular React component using `Field`, `DraftInput`, and `<select>` primitives from `agent-config-primitives`. It reads/writes via `eff()` (read effective value) and `mark()` (write dirty value). Adding an ordered-list component is straightforward React — build a `RoutingRulesEditor` component with add/remove/reorder + JSON toggle, wire it with `mark("adapterConfig", "sessionKeyRouting", rules)`. No framework extension needed. A4 flag cleared.
+
+2. ~~**A6 — project rules replace or coexist with project sessionKey?**~~ **Resolved:** Keep both. `sessionKey` is the data (user-defined value like a Slack channel ID), routing rules are the logic. `sessionKey` stays as `{{projectSessionKey}}` template variable. `sessionKeyRouting` is a new optional JSON column for per-project rules.
+
+3. ~~**Empty rules array vs null**~~ **Resolved:** Both null and [] = fall through to agent-level rules.

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,10 +40,12 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.7",
+    "@testing-library/react": "^16.2.0",
     "@types/node": "^25.2.3",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^4.0.7",
     "typescript": "^5.7.3",
     "vite": "^6.1.0",

--- a/ui/src/adapters/openclaw-gateway/config-fields.test.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.test.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { OpenClawGatewayConfigFields } from "./config-fields";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+function Harness({ markSpy }: { markSpy: ReturnType<typeof vi.fn> }) {
+  const [config, setConfig] = useState<Record<string, unknown>>({
+    sessionKeyStrategy: "fixed",
+    sessionKey: "paperclip",
+  });
+
+  return (
+    <TooltipProvider>
+      <OpenClawGatewayConfigFields
+        mode="edit"
+        isCreate={false}
+        adapterType="openclaw_gateway"
+        values={null}
+        set={null}
+        config={config}
+        eff={(_, field, original) => (field in config ? (config[field] as typeof original) : original)}
+        mark={(group, field, value) => {
+          markSpy(group, field, value);
+          setConfig((previous) => ({ ...previous, [field]: value }));
+        }}
+        models={[]}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe("OpenClawGatewayConfigFields", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("writes session key routing updates through mark(adapterConfig, sessionKeyRouting, rules)", () => {
+    const mark = vi.fn();
+
+    render(<Harness markSpy={mark} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    fireEvent.change(screen.getByLabelText("Routing pattern 1"), {
+      target: { value: "assignment:*" },
+    });
+    fireEvent.change(screen.getByLabelText("Session key template 1"), {
+      target: { value: "{{projectSessionKey}}" },
+    });
+
+    expect(mark).toHaveBeenCalledWith("adapterConfig", "sessionKeyRouting", [{ pattern: "", sessionKey: "" }]);
+    expect(mark).toHaveBeenLastCalledWith("adapterConfig", "sessionKeyRouting", [
+      { pattern: "assignment:*", sessionKey: "{{projectSessionKey}}" },
+    ]);
+
+    expect(screen.getByRole("combobox")).toBeTruthy();
+    expect(screen.getByDisplayValue("paperclip")).toBeTruthy();
+  });
+});

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -6,6 +6,11 @@ import {
   DraftInput,
   help,
 } from "../../components/agent-config-primitives";
+import {
+  RoutingRulesEditor,
+  parseRoutingRules,
+  type RoutingRule,
+} from "../../components/RoutingRulesEditor";
 
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
@@ -91,6 +96,12 @@ export function OpenClawGatewayConfigFields({
     "sessionKeyStrategy",
     String(config.sessionKeyStrategy ?? "fixed"),
   );
+  const sessionRoutingRules = parseRoutingRules(
+    eff("adapterConfig", "sessionKeyRouting", config.sessionKeyRouting),
+  );
+  const commitSessionRoutingRules = (rules: RoutingRule[]) => {
+    mark("adapterConfig", "sessionKeyRouting", rules.length > 0 ? rules : undefined);
+  };
 
   return (
     <>
@@ -166,6 +177,16 @@ export function OpenClawGatewayConfigFields({
               />
             </Field>
           )}
+
+          <Field
+            label="Session key routing"
+            hint="Optional ordered routing rules. Pattern matches source:reason and session key supports template variables like {{projectSessionKey}}."
+          >
+            <RoutingRulesEditor
+              rules={sessionRoutingRules}
+              onChange={commitSessionRoutingRules}
+            />
+          </Field>
 
           <SecretField
             label="Gateway auth token (x-openclaw-token)"

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -154,6 +154,13 @@ export function NewProjectDialog() {
     setWorkspaceError(null);
 
     try {
+      const validSessionKeyRouting = sessionKeyRouting
+        .map((rule) => ({
+          pattern: rule.pattern.trim(),
+          sessionKey: rule.sessionKey.trim(),
+        }))
+        .filter((rule) => rule.pattern.length > 0 && rule.sessionKey.length > 0);
+
       const created = await createProject.mutateAsync({
         name: name.trim(),
         description: description.trim() || undefined,
@@ -162,7 +169,7 @@ export function NewProjectDialog() {
         ...(goalIds.length > 0 ? { goalIds } : {}),
         ...(targetDate ? { targetDate } : {}),
         ...(sessionKey.trim() ? { sessionKey: sessionKey.trim() } : {}),
-        ...(sessionKeyRouting.length > 0 ? { sessionKeyRouting } : {}),
+        ...(validSessionKeyRouting.length > 0 ? { sessionKeyRouting: validSessionKeyRouting } : {}),
       });
 
       const workspacePayloads: Array<Record<string, unknown>> = [];

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -32,6 +32,7 @@ import { cn } from "../lib/utils";
 import { MarkdownEditor, type MarkdownEditorRef } from "./MarkdownEditor";
 import { StatusBadge } from "./StatusBadge";
 import { ChoosePathButton } from "./PathInstructionsModal";
+import { RoutingRulesEditor, type RoutingRule } from "./RoutingRulesEditor";
 
 const projectStatuses = [
   { value: "backlog", label: "Backlog" },
@@ -54,6 +55,7 @@ export function NewProjectDialog() {
   const [goalIds, setGoalIds] = useState<string[]>([]);
   const [targetDate, setTargetDate] = useState("");
   const [sessionKey, setSessionKey] = useState("");
+  const [sessionKeyRouting, setSessionKeyRouting] = useState<RoutingRule[]>([]);
   const [expanded, setExpanded] = useState(false);
   const [workspaceSetup, setWorkspaceSetup] = useState<WorkspaceSetup>("none");
   const [workspaceLocalPath, setWorkspaceLocalPath] = useState("");
@@ -89,6 +91,7 @@ export function NewProjectDialog() {
     setGoalIds([]);
     setTargetDate("");
     setSessionKey("");
+    setSessionKeyRouting([]);
     setExpanded(false);
     setWorkspaceSetup("none");
     setWorkspaceLocalPath("");
@@ -159,6 +162,7 @@ export function NewProjectDialog() {
         ...(goalIds.length > 0 ? { goalIds } : {}),
         ...(targetDate ? { targetDate } : {}),
         ...(sessionKey.trim() ? { sessionKey: sessionKey.trim() } : {}),
+        ...(sessionKeyRouting.length > 0 ? { sessionKeyRouting } : {}),
       });
 
       const workspacePayloads: Array<Record<string, unknown>> = [];
@@ -467,6 +471,13 @@ export function NewProjectDialog() {
             onChange={(e) => setSessionKey(e.target.value)}
             placeholder="e.g. paperclip:my-project"
           />
+          <div className="mt-3 space-y-1.5">
+            <label className="block text-xs text-muted-foreground">Session Key Routing</label>
+            <RoutingRulesEditor
+              rules={sessionKeyRouting}
+              onChange={setSessionKeyRouting}
+            />
+          </div>
         </div>
 
         {/* Footer */}

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -400,6 +400,7 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
           <RoutingRulesEditor
             rules={sessionKeyRoutingDraft}
             onChange={saveSessionKeyRouting}
+            immediate={false}
           />
         </div>
       </div>

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -15,6 +15,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ExternalLink, Github, Plus, Trash2, X } from "lucide-react";
 import { ChoosePathButton } from "./PathInstructionsModal";
+import { RoutingRulesEditor, parseRoutingRules, type RoutingRule } from "./RoutingRulesEditor";
 
 const PROJECT_STATUSES = [
   { value: "backlog", label: "Backlog" },
@@ -85,6 +86,9 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
   const [workspaceRepoUrl, setWorkspaceRepoUrl] = useState("");
   const [workspaceError, setWorkspaceError] = useState<string | null>(null);
   const [sessionKeyDraft, setSessionKeyDraft] = useState(project.sessionKey ?? "");
+  const [sessionKeyRoutingDraft, setSessionKeyRoutingDraft] = useState<RoutingRule[]>(
+    parseRoutingRules(project.sessionKeyRouting),
+  );
 
   const { data: allGoals } = useQuery({
     queryKey: queryKeys.goals.list(selectedCompanyId!),
@@ -111,6 +115,10 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
   useEffect(() => {
     setSessionKeyDraft(project.sessionKey ?? "");
   }, [project.id, project.sessionKey]);
+
+  useEffect(() => {
+    setSessionKeyRoutingDraft(parseRoutingRules(project.sessionKeyRouting));
+  }, [project.id, project.sessionKeyRouting]);
 
   const invalidateProject = () => {
     queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(project.id) });
@@ -265,6 +273,20 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
     onUpdate({ sessionKey: nextValue });
   };
 
+  const saveSessionKeyRouting = (rules: RoutingRule[]) => {
+    setSessionKeyRoutingDraft(rules);
+    if (!onUpdate) return;
+
+    const nextValue = rules.length > 0 ? rules : null;
+    const currentValue = parseRoutingRules(project.sessionKeyRouting);
+    const currentNormalized = currentValue.length > 0 ? currentValue : null;
+    if (JSON.stringify(nextValue) === JSON.stringify(currentNormalized)) {
+      return;
+    }
+
+    onUpdate({ sessionKeyRouting: nextValue });
+  };
+
   return (
     <div className="space-y-4">
       <div className="space-y-1">
@@ -373,6 +395,13 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
             <span className="text-sm">{project.sessionKey ?? "None"}</span>
           )}
         </PropertyRow>
+        <div className="py-1.5 space-y-1.5">
+          <span className="text-xs text-muted-foreground">Session Key Routing</span>
+          <RoutingRulesEditor
+            rules={sessionKeyRoutingDraft}
+            onChange={saveSessionKeyRouting}
+          />
+        </div>
       </div>
 
       <Separator />

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -276,6 +276,10 @@ export function ProjectProperties({ project, onUpdate }: ProjectPropertiesProps)
   const saveSessionKeyRouting = (rules: RoutingRule[]) => {
     setSessionKeyRoutingDraft(rules);
     if (!onUpdate) return;
+    const hasIncompleteRule = rules.some((rule) => !rule.pattern.trim() || !rule.sessionKey.trim());
+    if (hasIncompleteRule) {
+      return;
+    }
 
     const nextValue = rules.length > 0 ? rules : null;
     const currentValue = parseRoutingRules(project.sessionKeyRouting);

--- a/ui/src/components/RoutingRulesEditor.tsx
+++ b/ui/src/components/RoutingRulesEditor.tsx
@@ -9,6 +9,7 @@ export type RoutingRule = {
 type RoutingRulesEditorProps = {
   rules: RoutingRule[];
   onChange: (rules: RoutingRule[]) => void;
+  immediate?: boolean;
   className?: string;
 };
 
@@ -54,7 +55,7 @@ function moveRule(rules: RoutingRule[], fromIndex: number, toIndex: number): Rou
   return next;
 }
 
-export function RoutingRulesEditor({ rules, onChange, className }: RoutingRulesEditorProps) {
+export function RoutingRulesEditor({ rules, onChange, immediate = true, className }: RoutingRulesEditorProps) {
   const normalizedRules = useMemo(() => cloneRules(parseRoutingRules(rules)), [rules]);
   const [jsonMode, setJsonMode] = useState(false);
   const [jsonDraft, setJsonDraft] = useState("");
@@ -74,26 +75,40 @@ export function RoutingRulesEditor({ rules, onChange, className }: RoutingRulesE
     onChange(next);
   };
 
-  const handleJsonChange = (value: string) => {
-    setJsonDraft(value);
-
+  const parseJsonRules = (value: string): RoutingRule[] | null => {
     let parsedValue: unknown;
     try {
       parsedValue = JSON.parse(value);
     } catch {
       setJsonError("Invalid JSON.");
-      return;
+      return null;
     }
 
     const parsedRules = parseRoutingRules(parsedValue);
     const parsedArrayLength = Array.isArray(parsedValue) ? parsedValue.length : -1;
     if (!Array.isArray(parsedValue) || parsedRules.length !== parsedArrayLength) {
       setJsonError("JSON must be an array of { pattern, sessionKey } objects.");
-      return;
+      return null;
     }
 
     setJsonError(null);
-    onChange(parsedRules);
+    return parsedRules;
+  };
+
+  const handleJsonChange = (value: string) => {
+    setJsonDraft(value);
+    const parsedRules = parseJsonRules(value);
+    if (immediate && parsedRules) {
+      onChange(parsedRules);
+    }
+  };
+
+  const handleJsonBlur = () => {
+    if (immediate) return;
+    const parsedRules = parseJsonRules(jsonDraft);
+    if (parsedRules) {
+      onChange(parsedRules);
+    }
   };
 
   return (
@@ -125,6 +140,7 @@ export function RoutingRulesEditor({ rules, onChange, className }: RoutingRulesE
             className={inputClass + " min-h-[180px] resize-y"}
             value={jsonDraft}
             onChange={(event) => handleJsonChange(event.target.value)}
+            onBlur={handleJsonBlur}
             placeholder='[{"pattern":"timer:*","sessionKey":"heartbeat"}]'
           />
           {jsonError ? (
@@ -141,17 +157,29 @@ export function RoutingRulesEditor({ rules, onChange, className }: RoutingRulesE
                 aria-label={`Routing pattern ${index + 1}`}
                 value={rule.pattern}
                 onCommit={(value) => updateRule(index, { pattern: value })}
-                immediate
+                immediate={immediate}
                 className={inputClass}
                 placeholder="automation:issue_*"
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    (event.target as HTMLInputElement).blur();
+                  }
+                }}
               />
               <DraftInput
                 aria-label={`Session key template ${index + 1}`}
                 value={rule.sessionKey}
                 onCommit={(value) => updateRule(index, { sessionKey: value })}
-                immediate
+                immediate={immediate}
                 className={inputClass}
                 placeholder="{{projectSessionKey}}"
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    (event.target as HTMLInputElement).blur();
+                  }
+                }}
               />
               <div className="flex items-center gap-1">
                 <button

--- a/ui/src/components/RoutingRulesEditor.tsx
+++ b/ui/src/components/RoutingRulesEditor.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useMemo, useState } from "react";
+import { DraftInput } from "./agent-config-primitives";
+
+export type RoutingRule = {
+  pattern: string;
+  sessionKey: string;
+};
+
+type RoutingRulesEditorProps = {
+  rules: RoutingRule[];
+  onChange: (rules: RoutingRule[]) => void;
+  className?: string;
+};
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+const emptyRule: RoutingRule = {
+  pattern: "",
+  sessionKey: "",
+};
+
+function cloneRules(rules: RoutingRule[]): RoutingRule[] {
+  return rules.map((rule) => ({
+    pattern: rule.pattern,
+    sessionKey: rule.sessionKey,
+  }));
+}
+
+export function parseRoutingRules(value: unknown): RoutingRule[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const parsed: RoutingRule[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const pattern = (entry as Record<string, unknown>).pattern;
+    const sessionKey = (entry as Record<string, unknown>).sessionKey;
+    if (typeof pattern !== "string" || typeof sessionKey !== "string") continue;
+    parsed.push({ pattern, sessionKey });
+  }
+
+  return parsed;
+}
+
+function moveRule(rules: RoutingRule[], fromIndex: number, toIndex: number): RoutingRule[] {
+  if (toIndex < 0 || toIndex >= rules.length || fromIndex === toIndex) {
+    return rules;
+  }
+  const next = cloneRules(rules);
+  const [item] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, item);
+  return next;
+}
+
+export function RoutingRulesEditor({ rules, onChange, className }: RoutingRulesEditorProps) {
+  const normalizedRules = useMemo(() => cloneRules(parseRoutingRules(rules)), [rules]);
+  const [jsonMode, setJsonMode] = useState(false);
+  const [jsonDraft, setJsonDraft] = useState("");
+  const [jsonError, setJsonError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!jsonMode) return;
+    setJsonDraft(JSON.stringify(normalizedRules, null, 2));
+  }, [jsonMode, normalizedRules]);
+
+  const updateRule = (index: number, patch: Partial<RoutingRule>) => {
+    const next = cloneRules(normalizedRules);
+    next[index] = {
+      ...next[index],
+      ...patch,
+    };
+    onChange(next);
+  };
+
+  const handleJsonChange = (value: string) => {
+    setJsonDraft(value);
+
+    let parsedValue: unknown;
+    try {
+      parsedValue = JSON.parse(value);
+    } catch {
+      setJsonError("Invalid JSON.");
+      return;
+    }
+
+    const parsedRules = parseRoutingRules(parsedValue);
+    const parsedArrayLength = Array.isArray(parsedValue) ? parsedValue.length : -1;
+    if (!Array.isArray(parsedValue) || parsedRules.length !== parsedArrayLength) {
+      setJsonError("JSON must be an array of { pattern, sessionKey } objects.");
+      return;
+    }
+
+    setJsonError(null);
+    onChange(parsedRules);
+  };
+
+  return (
+    <div className={className ?? "space-y-2"}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-muted-foreground">Ordered rules, first match wins.</span>
+        <button
+          type="button"
+          className="inline-flex items-center rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent/50 transition-colors"
+          onClick={() => {
+            setJsonMode((current) => {
+              const next = !current;
+              if (next) {
+                setJsonDraft(JSON.stringify(normalizedRules, null, 2));
+                setJsonError(null);
+              }
+              return next;
+            });
+          }}
+        >
+          {jsonMode ? "Edit as Rows" : "Edit as JSON"}
+        </button>
+      </div>
+
+      {jsonMode ? (
+        <div className="space-y-1.5">
+          <textarea
+            aria-label="Session key routing JSON"
+            className={inputClass + " min-h-[180px] resize-y"}
+            value={jsonDraft}
+            onChange={(event) => handleJsonChange(event.target.value)}
+            placeholder='[{"pattern":"timer:*","sessionKey":"heartbeat"}]'
+          />
+          {jsonError ? (
+            <div role="alert" className="text-xs text-destructive">
+              {jsonError}
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {normalizedRules.map((rule, index) => (
+            <div key={index} className="grid grid-cols-[1fr_1fr_auto] gap-2 items-start">
+              <DraftInput
+                aria-label={`Routing pattern ${index + 1}`}
+                value={rule.pattern}
+                onCommit={(value) => updateRule(index, { pattern: value })}
+                immediate
+                className={inputClass}
+                placeholder="automation:issue_*"
+              />
+              <DraftInput
+                aria-label={`Session key template ${index + 1}`}
+                value={rule.sessionKey}
+                onCommit={(value) => updateRule(index, { sessionKey: value })}
+                immediate
+                className={inputClass}
+                placeholder="{{projectSessionKey}}"
+              />
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  aria-label={`Move rule ${index + 1} up`}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border text-xs text-muted-foreground hover:bg-accent/50 transition-colors disabled:opacity-40"
+                  disabled={index === 0}
+                  onClick={() => onChange(moveRule(normalizedRules, index, index - 1))}
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Move rule ${index + 1} down`}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border text-xs text-muted-foreground hover:bg-accent/50 transition-colors disabled:opacity-40"
+                  disabled={index === normalizedRules.length - 1}
+                  onClick={() => onChange(moveRule(normalizedRules, index, index + 1))}
+                >
+                  ↓
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Remove rule ${index + 1}`}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border text-xs text-muted-foreground hover:bg-accent/50 transition-colors"
+                  onClick={() => onChange(normalizedRules.filter((_, entryIndex) => entryIndex !== index))}
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            className="inline-flex items-center rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent/50 transition-colors"
+            onClick={() => onChange([...normalizedRules, { ...emptyRule }])}
+          >
+            Add rule
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/__tests__/ProjectSessionKeyRouting.test.tsx
+++ b/ui/src/components/__tests__/ProjectSessionKeyRouting.test.tsx
@@ -160,25 +160,21 @@ describe("Project session key routing UI", () => {
     fireEvent.blur(sessionKeyInput);
 
     expect(onUpdate).toHaveBeenCalledWith({ sessionKey: "paperclip:updated" });
+    expect(onUpdate).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    expect(onUpdate).toHaveBeenCalledTimes(1);
     fireEvent.change(screen.getByLabelText("Routing pattern 1"), {
       target: { value: "assignment:*" },
     });
     fireEvent.blur(screen.getByLabelText("Routing pattern 1"));
-    expect(onUpdate).not.toHaveBeenCalledWith({
-      sessionKeyRouting: [
-        {
-          pattern: "assignment:*",
-          sessionKey: "{{projectSessionKey}}",
-        },
-      ],
-    });
+    expect(onUpdate).toHaveBeenCalledTimes(1);
     fireEvent.change(screen.getByLabelText("Session key template 1"), {
       target: { value: "{{projectSessionKey}}" },
     });
     fireEvent.blur(screen.getByLabelText("Session key template 1"));
 
+    expect(onUpdate).toHaveBeenCalledTimes(2);
     expect(onUpdate).toHaveBeenLastCalledWith({
       sessionKeyRouting: [
         {

--- a/ui/src/components/__tests__/ProjectSessionKeyRouting.test.tsx
+++ b/ui/src/components/__tests__/ProjectSessionKeyRouting.test.tsx
@@ -165,11 +165,21 @@ describe("Project session key routing UI", () => {
     fireEvent.change(screen.getByLabelText("Routing pattern 1"), {
       target: { value: "assignment:*" },
     });
+    fireEvent.blur(screen.getByLabelText("Routing pattern 1"));
+    expect(onUpdate).not.toHaveBeenCalledWith({
+      sessionKeyRouting: [
+        {
+          pattern: "assignment:*",
+          sessionKey: "{{projectSessionKey}}",
+        },
+      ],
+    });
     fireEvent.change(screen.getByLabelText("Session key template 1"), {
       target: { value: "{{projectSessionKey}}" },
     });
+    fireEvent.blur(screen.getByLabelText("Session key template 1"));
 
-    expect(onUpdate).toHaveBeenCalledWith({
+    expect(onUpdate).toHaveBeenLastCalledWith({
       sessionKeyRouting: [
         {
           pattern: "assignment:*",

--- a/ui/src/components/__tests__/ProjectSessionKeyRouting.test.tsx
+++ b/ui/src/components/__tests__/ProjectSessionKeyRouting.test.tsx
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Project } from "@paperclipai/shared";
+import { NewProjectDialog } from "../NewProjectDialog";
+import { ProjectProperties } from "../ProjectProperties";
+
+const mocks = vi.hoisted(() => ({
+  closeNewProject: vi.fn(),
+  projectsCreate: vi.fn(),
+  projectsCreateWorkspace: vi.fn(),
+  goalsList: vi.fn(),
+  assetsUploadImage: vi.fn(),
+}));
+
+vi.mock("../../context/DialogContext", () => ({
+  useDialog: () => ({
+    newProjectOpen: true,
+    closeNewProject: mocks.closeNewProject,
+  }),
+}));
+
+vi.mock("../../context/CompanyContext", () => ({
+  useCompany: () => ({
+    selectedCompanyId: "company-1",
+    selectedCompany: {
+      id: "company-1",
+      name: "Paperclip Co",
+    },
+  }),
+}));
+
+vi.mock("../../api/projects", () => ({
+  projectsApi: {
+    create: mocks.projectsCreate,
+    createWorkspace: mocks.projectsCreateWorkspace,
+  },
+}));
+
+vi.mock("../../api/goals", () => ({
+  goalsApi: {
+    list: mocks.goalsList,
+  },
+}));
+
+vi.mock("../../api/assets", () => ({
+  assetsApi: {
+    uploadImage: mocks.assetsUploadImage,
+  },
+}));
+
+function renderWithQuery(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        {ui}
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function buildProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "project-1",
+    companyId: "company-1",
+    urlKey: "project-1",
+    goalId: null,
+    goalIds: [],
+    goals: [],
+    name: "Project One",
+    description: null,
+    status: "planned",
+    leadAgentId: null,
+    targetDate: null,
+    sessionKey: "paperclip:existing",
+    sessionKeyRouting: null,
+    color: "#0ea5e9",
+    workspaces: [],
+    primaryWorkspace: null,
+    archivedAt: null,
+    createdAt: new Date("2026-03-11T00:00:00.000Z"),
+    updatedAt: new Date("2026-03-11T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("Project session key routing UI", () => {
+  it("submits sessionKeyRouting from New Project dialog while preserving sessionKey", async () => {
+    mocks.goalsList.mockResolvedValue([]);
+    mocks.projectsCreate.mockResolvedValue({ id: "project-123" });
+    mocks.projectsCreateWorkspace.mockResolvedValue({});
+
+    renderWithQuery(<NewProjectDialog />);
+
+    fireEvent.change(screen.getByPlaceholderText("Project name"), {
+      target: { value: "Session Routing Project" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("e.g. paperclip:my-project"), {
+      target: { value: "paperclip:my-project" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    fireEvent.change(screen.getByLabelText("Routing pattern 1"), {
+      target: { value: "automation:issue_*" },
+    });
+    fireEvent.change(screen.getByLabelText("Session key template 1"), {
+      target: { value: "{{projectSessionKey}}" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create project" }));
+
+    await waitFor(() => {
+      expect(mocks.projectsCreate).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mocks.projectsCreate).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        name: "Session Routing Project",
+        sessionKey: "paperclip:my-project",
+        sessionKeyRouting: [
+          {
+            pattern: "automation:issue_*",
+            sessionKey: "{{projectSessionKey}}",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("persists routing rule edits in Project Properties and keeps Session Key behavior", () => {
+    mocks.goalsList.mockResolvedValue([]);
+    const onUpdate = vi.fn();
+
+    renderWithQuery(
+      <ProjectProperties
+        project={buildProject()}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    const sessionKeyInput = screen.getByPlaceholderText("e.g. paperclip:my-project");
+    fireEvent.change(sessionKeyInput, {
+      target: { value: "paperclip:updated" },
+    });
+    fireEvent.blur(sessionKeyInput);
+
+    expect(onUpdate).toHaveBeenCalledWith({ sessionKey: "paperclip:updated" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    fireEvent.change(screen.getByLabelText("Routing pattern 1"), {
+      target: { value: "assignment:*" },
+    });
+    fireEvent.change(screen.getByLabelText("Session key template 1"), {
+      target: { value: "{{projectSessionKey}}" },
+    });
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      sessionKeyRouting: [
+        {
+          pattern: "assignment:*",
+          sessionKey: "{{projectSessionKey}}",
+        },
+      ],
+    });
+  });
+});

--- a/ui/src/components/__tests__/ProjectSessionKeyRouting.test.tsx
+++ b/ui/src/components/__tests__/ProjectSessionKeyRouting.test.tsx
@@ -142,6 +142,36 @@ describe("Project session key routing UI", () => {
     );
   });
 
+  it("omits sessionKeyRouting on create when all routing rows are incomplete", async () => {
+    mocks.goalsList.mockResolvedValue([]);
+    mocks.projectsCreate.mockResolvedValue({ id: "project-234" });
+    mocks.projectsCreateWorkspace.mockResolvedValue({});
+
+    renderWithQuery(<NewProjectDialog />);
+
+    fireEvent.change(screen.getByPlaceholderText("Project name"), {
+      target: { value: "Incomplete Routing Project" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    fireEvent.change(screen.getByLabelText("Routing pattern 1"), {
+      target: { value: "assignment:*" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create project" }));
+
+    await waitFor(() => {
+      expect(mocks.projectsCreate).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mocks.projectsCreate).toHaveBeenCalledWith(
+      "company-1",
+      expect.not.objectContaining({
+        sessionKeyRouting: expect.anything(),
+      }),
+    );
+  });
+
   it("persists routing rule edits in Project Properties and keeps Session Key behavior", () => {
     mocks.goalsList.mockResolvedValue([]);
     const onUpdate = vi.fn();

--- a/ui/src/components/__tests__/RoutingRulesEditor.test.tsx
+++ b/ui/src/components/__tests__/RoutingRulesEditor.test.tsx
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  RoutingRulesEditor,
+  type RoutingRule,
+} from "../RoutingRulesEditor";
+
+type HarnessProps = {
+  initialRules?: RoutingRule[];
+  onRules?: (rules: RoutingRule[]) => void;
+};
+
+function Harness({ initialRules = [], onRules }: HarnessProps) {
+  const [rules, setRules] = useState<RoutingRule[]>(initialRules);
+
+  return (
+    <RoutingRulesEditor
+      rules={rules}
+      onChange={(next) => {
+        setRules(next);
+        onRules?.(next);
+      }}
+    />
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("RoutingRulesEditor", () => {
+  it("supports add, remove, reorder and emits ordered rules", () => {
+    const onRules = vi.fn();
+    render(<Harness onRules={onRules} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+
+    fireEvent.change(screen.getByLabelText("Routing pattern 1"), {
+      target: { value: "assignment:*" },
+    });
+    fireEvent.change(screen.getByLabelText("Session key template 1"), {
+      target: { value: "route:a" },
+    });
+    fireEvent.change(screen.getByLabelText("Routing pattern 2"), {
+      target: { value: "timer:*" },
+    });
+    fireEvent.change(screen.getByLabelText("Session key template 2"), {
+      target: { value: "route:b" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Move rule 2 up" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove rule 2" }));
+
+    const calls = onRules.mock.calls as Array<[RoutingRule[]]>;
+    expect(calls[calls.length - 1][0]).toEqual([
+      {
+        pattern: "timer:*",
+        sessionKey: "route:b",
+      },
+    ]);
+  });
+
+  it("round-trips valid JSON and preserves rule order/values", () => {
+    const onRules = vi.fn();
+    render(
+      <Harness
+        initialRules={[
+          { pattern: "timer:*", sessionKey: "heartbeat" },
+          { pattern: "*", sessionKey: "fallback" },
+        ]}
+        onRules={onRules}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit as JSON" }));
+    const textarea = screen.getByLabelText("Session key routing JSON");
+
+    fireEvent.change(textarea, {
+      target: {
+        value: JSON.stringify(
+          [
+            { pattern: "assignment:*", sessionKey: "{{projectSessionKey}}" },
+            { pattern: "*", sessionKey: "paperclip" },
+          ],
+          null,
+          2,
+        ),
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit as Rows" }));
+
+    expect((screen.getByLabelText("Routing pattern 1") as HTMLInputElement).value).toBe("assignment:*");
+    expect((screen.getByLabelText("Session key template 1") as HTMLInputElement).value).toBe("{{projectSessionKey}}");
+    expect((screen.getByLabelText("Routing pattern 2") as HTMLInputElement).value).toBe("*");
+    expect((screen.getByLabelText("Session key template 2") as HTMLInputElement).value).toBe("paperclip");
+
+    const calls = onRules.mock.calls as Array<[RoutingRule[]]>;
+    expect(calls[calls.length - 1][0]).toEqual([
+      { pattern: "assignment:*", sessionKey: "{{projectSessionKey}}" },
+      { pattern: "*", sessionKey: "paperclip" },
+    ]);
+  });
+
+  it("shows JSON validation errors and keeps current rules when JSON is invalid", () => {
+    const onRules = vi.fn();
+    render(
+      <Harness
+        initialRules={[{ pattern: "timer:*", sessionKey: "heartbeat" }]}
+        onRules={onRules}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit as JSON" }));
+    fireEvent.change(screen.getByLabelText("Session key routing JSON"), {
+      target: { value: "not-json" },
+    });
+
+    expect(screen.getByRole("alert").textContent ?? "").toContain("Invalid JSON");
+    expect(onRules).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit as Rows" }));
+
+    expect((screen.getByLabelText("Routing pattern 1") as HTMLInputElement).value).toBe("timer:*");
+    expect((screen.getByLabelText("Session key template 1") as HTMLInputElement).value).toBe("heartbeat");
+  });
+});

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     environment: "jsdom",
   },


### PR DESCRIPTION
## Summary
- implement V1 routing engine for OpenClaw adapter with pattern matching and template interpolation fallback behavior
- add V2 reusable `RoutingRulesEditor` and wire it into OpenClaw adapter config UI
- add V3 per-project `sessionKeyRouting` storage, context enrichment, and project-over-agent routing priority
- add V4 project UI wiring in New Project and Project Properties, including tests for create/update payloads
- include follow-up fix to keep strategy fallback when no routing rule resolves `projectSessionKey`

## Testing
- pnpm test:run server/src/__tests__/openclaw-gateway-adapter.test.ts

Closes #9
