### PR TITLE
feat: add routing rules help reference modal

### DIFF
--- a/ui/src/components/RoutingRulesEditor.tsx
+++ b/ui/src/components/RoutingRulesEditor.tsx
@@ -1,4 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "./ui/dialog";
 import { DraftInput } from "./agent-config-primitives";
 
 export type RoutingRule = {
@@ -20,6 +30,34 @@ const emptyRule: RoutingRule = {
   pattern: "",
   sessionKey: "",
 };
+
+const sourceReasonReference: Array<{ source: string; reasons: string }> = [
+  { source: "timer", reasons: "heartbeat_timer, interval_elapsed" },
+  { source: "assignment", reasons: "issue_assigned, issue_checked_out" },
+  {
+    source: "automation",
+    reasons: "issue_status_changed, issue_comment_mentioned, issue_commented, issue_reopened_via_comment",
+  },
+  { source: "on_demand", reasons: "manual, ping, callback, system" },
+];
+
+const patternExamples: Array<{ pattern: string; meaning: string }> = [
+  { pattern: "*", meaning: "Matches every source:reason event." },
+  { pattern: "timer:*", meaning: "Matches any timer reason." },
+  { pattern: "*:issue_assigned", meaning: "Matches issue_assigned from any source." },
+  { pattern: "automation:issue_*", meaning: "Matches automation reasons starting with issue_." },
+  { pattern: "timer:heartbeat_timer", meaning: "Exact match for one source:reason pair." },
+];
+
+const templateVariables: Array<{ variable: string; description: string }> = [
+  { variable: "wakeSource", description: "Event source used by the pattern match." },
+  { variable: "wakeReason", description: "Event reason used by the pattern match." },
+  { variable: "projectId", description: "Project id for project-scoped events." },
+  { variable: "projectSessionKey", description: "Project session key value when set on the project." },
+  { variable: "issueId", description: "Issue id when the wake event is issue-related." },
+  { variable: "runId", description: "Heartbeat run id for the current invocation." },
+  { variable: "agentId", description: "Agent id for the run currently being routed." },
+];
 
 function cloneRules(rules: RoutingRule[]): RoutingRule[] {
   return rules.map((rule) => ({
@@ -114,7 +152,128 @@ export function RoutingRulesEditor({ rules, onChange, immediate = true, classNam
   return (
     <div className={className ?? "space-y-2"}>
       <div className="flex items-center justify-between gap-2">
-        <span className="text-xs text-muted-foreground">Ordered rules, first match wins.</span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">Ordered rules, first match wins.</span>
+          {!jsonMode ? (
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button
+                  type="button"
+                  variant="link"
+                  size="xs"
+                  className="h-auto p-0 text-xs text-muted-foreground"
+                  aria-label="Routing rules reference"
+                >
+                  Reference
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-2xl">
+                <DialogHeader>
+                  <DialogTitle className="text-base">Routing Rules Reference</DialogTitle>
+                  <DialogDescription>
+                    Pattern syntax, source and reason values, routing examples, and template variables.
+                  </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-4 text-sm">
+                  <section className="space-y-2">
+                    <h3 className="text-sm font-semibold">Pattern Format</h3>
+                    <p className="text-muted-foreground">
+                      Patterns match against <span className="font-mono">source:reason</span> using glob wildcards.
+                    </p>
+                    <ul className="list-disc pl-5 text-muted-foreground">
+                      <li>
+                        Use <span className="font-mono">*</span> to match everything.
+                      </li>
+                      <li>
+                        Use <span className="font-mono">timer:*</span> to match a source with any reason.
+                      </li>
+                      <li>
+                        Use <span className="font-mono">*:issue_assigned</span> to match a reason from any source.
+                      </li>
+                      <li>
+                        Use <span className="font-mono">automation:issue_*</span> for prefix matching.
+                      </li>
+                    </ul>
+                  </section>
+
+                  <section className="space-y-2">
+                    <h3 className="text-sm font-semibold">Source / Reason Reference</h3>
+                    <div className="overflow-x-auto rounded-md border border-border">
+                      <table className="w-full text-left text-xs">
+                        <thead className="bg-accent/40">
+                          <tr>
+                            <th className="px-2 py-1.5 font-medium">Source</th>
+                            <th className="px-2 py-1.5 font-medium">Common Reasons</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {sourceReasonReference.map((entry) => (
+                            <tr key={entry.source} className="border-t border-border">
+                              <td className="px-2 py-1.5 font-mono">{entry.source}</td>
+                              <td className="px-2 py-1.5 font-mono">{entry.reasons}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </section>
+
+                  <section className="space-y-2">
+                    <h3 className="text-sm font-semibold">Pattern Matching Examples</h3>
+                    <div className="overflow-x-auto rounded-md border border-border">
+                      <table className="w-full text-left text-xs">
+                        <thead className="bg-accent/40">
+                          <tr>
+                            <th className="px-2 py-1.5 font-medium">Pattern</th>
+                            <th className="px-2 py-1.5 font-medium">Behavior</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {patternExamples.map((entry) => (
+                            <tr key={entry.pattern} className="border-t border-border">
+                              <td className="px-2 py-1.5 font-mono">{entry.pattern}</td>
+                              <td className="px-2 py-1.5">{entry.meaning}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </section>
+
+                  <section className="space-y-2">
+                    <h3 className="text-sm font-semibold">Template Variable Reference</h3>
+                    <div className="overflow-x-auto rounded-md border border-border">
+                      <table className="w-full text-left text-xs">
+                        <thead className="bg-accent/40">
+                          <tr>
+                            <th className="px-2 py-1.5 font-medium">Variable</th>
+                            <th className="px-2 py-1.5 font-medium">Description</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {templateVariables.map((entry) => (
+                            <tr key={entry.variable} className="border-t border-border">
+                              <td className="px-2 py-1.5 font-mono">{`{{${entry.variable}}}`}</td>
+                              <td className="px-2 py-1.5">{entry.description}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      If a template variable cannot be resolved (for example{" "}
+                      <span className="font-mono">{`{{projectSessionKey}}`}</span> when no project session key is
+                      available), that rule is skipped and evaluation continues to the next rule.
+                    </p>
+                  </section>
+                </div>
+
+                <DialogFooter showCloseButton />
+              </DialogContent>
+            </Dialog>
+          ) : null}
+        </div>
         <button
           type="button"
           className="inline-flex items-center rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-accent/50 transition-colors"

--- a/ui/src/components/RoutingRulesEditor.tsx
+++ b/ui/src/components/RoutingRulesEditor.tsx
@@ -55,6 +55,7 @@ const reasonReference: Array<{ reason: string; source: string; when: string }> =
 const patternExamples: Array<{ pattern: string; meaning: string }> = [
   { pattern: "*", meaning: "Matches every source:reason event." },
   { pattern: "timer:*", meaning: "Matches any timer reason." },
+  { pattern: "assignment:issue_assigned", meaning: "Exact match for assignment wake-ups when an issue is assigned." },
   { pattern: "*:issue_assigned", meaning: "Matches issue_assigned from any source." },
   { pattern: "automation:issue_*", meaning: "Matches automation reasons starting with issue_." },
   { pattern: "timer:heartbeat_timer", meaning: "Exact match for one source:reason pair." },

--- a/ui/src/components/RoutingRulesEditor.tsx
+++ b/ui/src/components/RoutingRulesEditor.tsx
@@ -31,14 +31,25 @@ const emptyRule: RoutingRule = {
   sessionKey: "",
 };
 
-const sourceReasonReference: Array<{ source: string; reasons: string }> = [
-  { source: "timer", reasons: "heartbeat_timer, interval_elapsed" },
-  { source: "assignment", reasons: "issue_assigned, issue_checked_out" },
-  {
-    source: "automation",
-    reasons: "issue_status_changed, issue_comment_mentioned, issue_commented, issue_reopened_via_comment",
-  },
-  { source: "on_demand", reasons: "manual, ping, callback, system" },
+const sourceReference: Array<{ source: string; when: string }> = [
+  { source: "timer", when: "Heartbeat timer fires" },
+  { source: "assignment", when: "Issue assigned to agent" },
+  { source: "automation", when: "Automated issue processing (comments, status changes, mentions)" },
+  { source: "on_demand", when: "Manual trigger or API call" },
+];
+
+const reasonReference: Array<{ reason: string; source: string; when: string }> = [
+  { reason: "heartbeat_timer", source: "timer", when: "Scheduled heartbeat interval elapsed" },
+  { reason: "issue_assigned", source: "assignment", when: "Issue assigned to this agent" },
+  { reason: "issue_status_changed", source: "automation", when: "Issue status was updated" },
+  { reason: "issue_comment_mentioned", source: "automation", when: "Agent mentioned in a comment" },
+  { reason: "issue_commented", source: "automation", when: "New comment on agent's issue" },
+  { reason: "issue_checked_out", source: "assignment", when: "Issue checked out to agent" },
+  { reason: "issue_reopened_via_comment", source: "automation", when: "Issue reopened via comment" },
+  { reason: "issue_execution_promoted", source: "automation", when: "Issue promoted for execution" },
+  { reason: "issue_execution_deferred", source: "automation", when: "Issue execution deferred" },
+  { reason: "approval_approved", source: "automation", when: "Approval request approved" },
+  { reason: "stale_checkout_run", source: "automation", when: "Stale checkout detected" },
 ];
 
 const patternExamples: Array<{ pattern: string; meaning: string }> = [
@@ -49,14 +60,18 @@ const patternExamples: Array<{ pattern: string; meaning: string }> = [
   { pattern: "timer:heartbeat_timer", meaning: "Exact match for one source:reason pair." },
 ];
 
-const templateVariables: Array<{ variable: string; description: string }> = [
-  { variable: "wakeSource", description: "Event source used by the pattern match." },
-  { variable: "wakeReason", description: "Event reason used by the pattern match." },
-  { variable: "projectId", description: "Project id for project-scoped events." },
-  { variable: "projectSessionKey", description: "Project session key value when set on the project." },
-  { variable: "issueId", description: "Issue id when the wake event is issue-related." },
-  { variable: "runId", description: "Heartbeat run id for the current invocation." },
-  { variable: "agentId", description: "Agent id for the run currently being routed." },
+const templateVariables: Array<{ variable: string; description: string; example: string }> = [
+  { variable: "agentId", description: "The agent's ID", example: "7be025d0-..." },
+  { variable: "projectId", description: "Current project ID", example: "abc123" },
+  {
+    variable: "projectSessionKey",
+    description: "Project's configured session key",
+    example: "slack:channel:c0ag0u06yka",
+  },
+  { variable: "issueId", description: "Issue being processed", example: "issue-42" },
+  { variable: "runId", description: "Current execution run ID", example: "run-xyz" },
+  { variable: "wakeSource", description: "Wake event source", example: "timer" },
+  { variable: "wakeReason", description: "Wake event reason", example: "issue_assigned" },
 ];
 
 function cloneRules(rules: RoutingRule[]): RoutingRule[] {
@@ -198,20 +213,44 @@ export function RoutingRulesEditor({ rules, onChange, immediate = true, classNam
                   </section>
 
                   <section className="space-y-2">
-                    <h3 className="text-sm font-semibold">Source / Reason Reference</h3>
+                    <h3 className="text-sm font-semibold">Sources</h3>
                     <div className="overflow-x-auto rounded-md border border-border">
                       <table className="w-full text-left text-xs">
                         <thead className="bg-accent/40">
                           <tr>
                             <th className="px-2 py-1.5 font-medium">Source</th>
-                            <th className="px-2 py-1.5 font-medium">Common Reasons</th>
+                            <th className="px-2 py-1.5 font-medium">When</th>
                           </tr>
                         </thead>
                         <tbody>
-                          {sourceReasonReference.map((entry) => (
+                          {sourceReference.map((entry) => (
                             <tr key={entry.source} className="border-t border-border">
                               <td className="px-2 py-1.5 font-mono">{entry.source}</td>
-                              <td className="px-2 py-1.5 font-mono">{entry.reasons}</td>
+                              <td className="px-2 py-1.5">{entry.when}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </section>
+
+                  <section className="space-y-2">
+                    <h3 className="text-sm font-semibold">Reasons</h3>
+                    <div className="overflow-x-auto rounded-md border border-border">
+                      <table className="w-full text-left text-xs">
+                        <thead className="bg-accent/40">
+                          <tr>
+                            <th className="px-2 py-1.5 font-medium">Reason</th>
+                            <th className="px-2 py-1.5 font-medium">Source</th>
+                            <th className="px-2 py-1.5 font-medium">When</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {reasonReference.map((entry) => (
+                            <tr key={entry.reason} className="border-t border-border">
+                              <td className="px-2 py-1.5 font-mono">{entry.reason}</td>
+                              <td className="px-2 py-1.5 font-mono">{entry.source}</td>
+                              <td className="px-2 py-1.5">{entry.when}</td>
                             </tr>
                           ))}
                         </tbody>
@@ -242,13 +281,14 @@ export function RoutingRulesEditor({ rules, onChange, immediate = true, classNam
                   </section>
 
                   <section className="space-y-2">
-                    <h3 className="text-sm font-semibold">Template Variable Reference</h3>
+                    <h3 className="text-sm font-semibold">Template Variables</h3>
                     <div className="overflow-x-auto rounded-md border border-border">
                       <table className="w-full text-left text-xs">
                         <thead className="bg-accent/40">
                           <tr>
                             <th className="px-2 py-1.5 font-medium">Variable</th>
                             <th className="px-2 py-1.5 font-medium">Description</th>
+                            <th className="px-2 py-1.5 font-medium">Example</th>
                           </tr>
                         </thead>
                         <tbody>
@@ -256,6 +296,7 @@ export function RoutingRulesEditor({ rules, onChange, immediate = true, classNam
                             <tr key={entry.variable} className="border-t border-border">
                               <td className="px-2 py-1.5 font-mono">{`{{${entry.variable}}}`}</td>
                               <td className="px-2 py-1.5">{entry.description}</td>
+                              <td className="px-2 py-1.5 font-mono">{entry.example}</td>
                             </tr>
                           ))}
                         </tbody>

--- a/ui/src/components/__tests__/RoutingRulesEditor.test.tsx
+++ b/ui/src/components/__tests__/RoutingRulesEditor.test.tsx
@@ -30,7 +30,7 @@ afterEach(() => {
 });
 
 describe("RoutingRulesEditor", () => {
-  it("shows a row-mode reference trigger and opens/closes the help modal with required sections", () => {
+  it("shows a row-mode reference trigger and opens/closes the help modal with required sections and content", () => {
     render(<Harness />);
 
     const trigger = screen.getByRole("button", { name: "Routing rules reference" });
@@ -40,9 +40,21 @@ describe("RoutingRulesEditor", () => {
 
     expect(screen.getByRole("heading", { name: "Routing Rules Reference" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Pattern Format" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Source / Reason Reference" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Sources" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Reasons" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Pattern Matching Examples" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Template Variable Reference" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Template Variables" })).toBeTruthy();
+
+    expect(screen.getByText("heartbeat_timer")).toBeTruthy();
+    expect(screen.getAllByText("issue_assigned").length).toBeGreaterThan(0);
+    expect(screen.getByText("issue_status_changed")).toBeTruthy();
+    expect(screen.getByText("manual trigger or API call", { exact: false })).toBeTruthy();
+    expect(screen.getByText("issue_execution_promoted")).toBeTruthy();
+    expect(screen.getByText("issue_execution_deferred")).toBeTruthy();
+    expect(screen.getByText("approval_approved")).toBeTruthy();
+    expect(screen.getByText("stale_checkout_run")).toBeTruthy();
+    expect(screen.getAllByText("{{projectSessionKey}}").length).toBeGreaterThan(0);
+    expect(screen.getByText("slack:channel:c0ag0u06yka")).toBeTruthy();
 
     fireEvent.click(screen.getAllByRole("button", { name: "Close" })[0]);
     expect(screen.queryByRole("heading", { name: "Routing Rules Reference" })).toBeNull();

--- a/ui/src/components/__tests__/RoutingRulesEditor.test.tsx
+++ b/ui/src/components/__tests__/RoutingRulesEditor.test.tsx
@@ -53,6 +53,7 @@ describe("RoutingRulesEditor", () => {
     expect(screen.getByText("issue_execution_deferred")).toBeTruthy();
     expect(screen.getByText("approval_approved")).toBeTruthy();
     expect(screen.getByText("stale_checkout_run")).toBeTruthy();
+    expect(screen.getByText("assignment:issue_assigned")).toBeTruthy();
     expect(screen.getAllByText("{{projectSessionKey}}").length).toBeGreaterThan(0);
     expect(screen.getByText("slack:channel:c0ag0u06yka")).toBeTruthy();
 

--- a/ui/src/components/__tests__/RoutingRulesEditor.test.tsx
+++ b/ui/src/components/__tests__/RoutingRulesEditor.test.tsx
@@ -30,6 +30,24 @@ afterEach(() => {
 });
 
 describe("RoutingRulesEditor", () => {
+  it("shows a row-mode reference trigger and opens/closes the help modal with required sections", () => {
+    render(<Harness />);
+
+    const trigger = screen.getByRole("button", { name: "Routing rules reference" });
+    expect(trigger).toBeTruthy();
+
+    fireEvent.click(trigger);
+
+    expect(screen.getByRole("heading", { name: "Routing Rules Reference" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Pattern Format" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Source / Reason Reference" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Pattern Matching Examples" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Template Variable Reference" })).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Close" })[0]);
+    expect(screen.queryByRole("heading", { name: "Routing Rules Reference" })).toBeNull();
+  });
+
   it("supports add, remove, reorder and emits ordered rules", () => {
     const onRules = vi.fn();
     render(<Harness onRules={onRules} />);


### PR DESCRIPTION
## Summary
- add a Reference trigger next to the Routing Rules header in row mode
- add an in-component Dialog with hardcoded reference content:
  - Pattern Format
  - Source / Reason Reference
  - Pattern Matching Examples
  - Template Variable Reference
- keep existing routing logic and row/JSON editor behavior unchanged
- add/update RoutingRulesEditor tests for the new help modal behavior

## Verification
- pnpm -r typecheck *(fails in existing cli files unrelated to this story: missing `disableSignUp` in CLI config typing)*
- pnpm test:run
- pnpm build
