### PR TITLE
feat: refactor OpenClaw routing template variables to payloadTemplate namespace

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -216,9 +216,12 @@ export function resolveSessionKeyFromRouting(input: {
   wakeReason: string | null;
   runId: string;
   issueId: string | null;
-  paperclipAgentId: string;
-  adapterAgentId: string | null;
-  routingVariables?: Record<string, unknown>;
+  payloadTemplate: Record<string, unknown> | null;
+  project: {
+    id: string | null;
+    name: string | null;
+    metadata: Record<string, unknown> | null;
+  };
   fallback: {
     strategy: SessionKeyStrategy;
     configuredSessionKey: string | null;
@@ -227,9 +230,13 @@ export function resolveSessionKeyFromRouting(input: {
   const wakeSource = input.wakeSource ?? "";
   const wakeReason = input.wakeReason ?? "";
   const key = `${wakeSource}:${wakeReason}`;
-  const variables: Record<string, unknown> = input.routingVariables ?? {
-    paperclipAgentId: input.paperclipAgentId,
-    adapterAgentId: input.adapterAgentId,
+  const variables: Record<string, unknown> = {
+    payloadTemplate: { ...(input.payloadTemplate ?? {}) },
+    project: {
+      id: input.project.id,
+      name: input.project.name,
+      metadata: input.project.metadata,
+    },
     issueId: input.issueId,
     runId: input.runId,
     wakeSource: input.wakeSource,
@@ -1180,22 +1187,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);
   const sessionKeyRouting = parseSessionKeyRouting(ctx.config.sessionKeyRouting);
   const configuredAgentId = nonEmpty(ctx.config.agentId);
-  const templateAgentId = nonEmpty(payloadTemplate.agentId);
-  const adapterAgentId = configuredAgentId ?? templateAgentId;
   const contextProject = asRecord(ctx.context.project);
-  const routingVariables: Record<string, unknown> = {
-    project: {
-      id: nonEmpty(contextProject?.id) ?? nonEmpty(ctx.context.projectId),
-      name: nonEmpty(contextProject?.name),
-      metadata: asRecord(contextProject?.metadata),
-    },
-    paperclipAgentId: ctx.agent.id,
-    adapterAgentId,
-    issueId: wakePayload.issueId,
-    runId: ctx.runId,
-    wakeSource: nonEmpty(ctx.context.wakeSource),
-    wakeReason: wakePayload.wakeReason,
-  };
   const sessionKey =
     sessionKeyStrategy === "routing"
       ? resolveSessionKeyFromRouting({
@@ -1204,9 +1196,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           wakeReason: wakePayload.wakeReason,
           runId: ctx.runId,
           issueId: wakePayload.issueId,
-          paperclipAgentId: ctx.agent.id,
-          adapterAgentId,
-          routingVariables,
+          payloadTemplate,
+          project: {
+            id: nonEmpty(contextProject?.id) ?? nonEmpty(ctx.context.projectId),
+            name: nonEmpty(contextProject?.name),
+            metadata: asRecord(contextProject?.metadata),
+          },
           fallback: {
             strategy: "issue",
             configuredSessionKey,

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -409,13 +409,14 @@ describe("openclaw gateway routing helpers", () => {
   });
 
   it("interpolates template variables with mustache and dollar styles", () => {
-    const text = interpolateTemplate("session:{{paperclipAgentId}}:${runId}:${issueId}:${adapterAgentId}", {
-      paperclipAgentId: "agent-1",
+    const text = interpolateTemplate("session:{{payloadTemplate.agentId}}:${runId}:${issueId}", {
+      payloadTemplate: {
+        agentId: "agent-1",
+      },
       runId: "run-1",
       issueId: "issue-1",
-      adapterAgentId: null,
     });
-    expect(text).toBe("session:agent-1:run-1:issue-1:");
+    expect(text).toBe("session:agent-1:run-1:issue-1");
   });
 
   it("resolves dot-path template variables", () => {
@@ -460,8 +461,14 @@ describe("openclaw gateway routing helpers", () => {
       wakeReason: "issue_assigned",
       runId: "run-1",
       issueId: "issue-1",
-      paperclipAgentId: "paperclip-agent-1",
-      adapterAgentId: "gateway-agent-1",
+      payloadTemplate: {
+        agentId: "gateway-agent-1",
+      },
+      project: {
+        id: null,
+        name: null,
+        metadata: null,
+      },
       fallback: {
         strategy: "run",
         configuredSessionKey: "fallback-session",
@@ -471,39 +478,99 @@ describe("openclaw gateway routing helpers", () => {
     expect(result).toBe("issue:issue-1");
   });
 
-  it("treats flat mustache vars as known when key exists with null value", () => {
+  it("resolves payloadTemplate dot-path variables", () => {
     const result = resolveSessionKeyFromRouting({
       routingRules: [
-        { pattern: "assignment:*", sessionKey: "route:{{adapterAgentId}}|{{issueId}}" },
+        { pattern: "assignment:*", sessionKey: "route:{{payloadTemplate.agentId}}|{{issueId}}" },
         { pattern: "assignment:*", sessionKey: "route:fallback" },
       ],
       wakeSource: "assignment",
       wakeReason: "issue_assigned",
       runId: "run-1",
       issueId: "issue-1",
-      paperclipAgentId: "paperclip-agent-1",
-      adapterAgentId: null,
+      payloadTemplate: {
+        agentId: "main",
+      },
+      project: {
+        id: null,
+        name: null,
+        metadata: null,
+      },
       fallback: {
         strategy: "fixed",
         configuredSessionKey: "fallback-session",
       },
     });
 
-    expect(result).toBe("route:|issue-1");
+    expect(result).toBe("route:main|issue-1");
+  });
+
+  it("handles null payloadTemplate and continues with flat system variables", () => {
+    const result = resolveSessionKeyFromRouting({
+      routingRules: [
+        { pattern: "assignment:*", sessionKey: "route:{{payloadTemplate.agentId}}" },
+        { pattern: "assignment:*", sessionKey: "route:{{wakeSource}}|{{issueId}}" },
+      ],
+      wakeSource: "assignment",
+      wakeReason: "issue_assigned",
+      runId: "run-1",
+      issueId: "issue-1",
+      payloadTemplate: null,
+      project: {
+        id: null,
+        name: null,
+        metadata: null,
+      },
+      fallback: {
+        strategy: "fixed",
+        configuredSessionKey: "fallback-session",
+      },
+    });
+
+    expect(result).toBe("route:assignment|issue-1");
+  });
+
+  it("handles empty payloadTemplate and continues with flat system variables", () => {
+    const result = resolveSessionKeyFromRouting({
+      routingRules: [
+        { pattern: "assignment:*", sessionKey: "route:{{payloadTemplate.agentId}}" },
+        { pattern: "assignment:*", sessionKey: "route:{{runId}}|{{issueId}}" },
+      ],
+      wakeSource: "assignment",
+      wakeReason: "issue_assigned",
+      runId: "run-1",
+      issueId: "issue-1",
+      payloadTemplate: {},
+      project: {
+        id: null,
+        name: null,
+        metadata: null,
+      },
+      fallback: {
+        strategy: "fixed",
+        configuredSessionKey: "fallback-session",
+      },
+    });
+
+    expect(result).toBe("route:run-1|issue-1");
   });
 
   it("does not gate routing on dollar-template variables", () => {
     const result = resolveSessionKeyFromRouting({
       routingRules: [
-        { pattern: "assignment:*", sessionKey: "route:${adapterAgentId}|{{issueId}}" },
+        { pattern: "assignment:*", sessionKey: "route:${payloadTemplate.agentId}|{{issueId}}" },
         { pattern: "assignment:*", sessionKey: "route:fallback" },
       ],
       wakeSource: "assignment",
       wakeReason: "issue_assigned",
       runId: "run-1",
       issueId: "issue-1",
-      paperclipAgentId: "paperclip-agent-1",
-      adapterAgentId: null,
+      payloadTemplate: {},
+      project: {
+        id: null,
+        name: null,
+        metadata: null,
+      },
       fallback: {
         strategy: "fixed",
         configuredSessionKey: "fallback-session",
@@ -520,8 +587,14 @@ describe("openclaw gateway routing helpers", () => {
       wakeReason: "issue_assigned",
       runId: "run-1",
       issueId: "issue-1",
-      paperclipAgentId: "paperclip-agent-1",
-      adapterAgentId: "gateway-agent-1",
+      payloadTemplate: {
+        agentId: "gateway-agent-1",
+      },
+      project: {
+        id: null,
+        name: null,
+        metadata: null,
+      },
       fallback: {
         strategy: "fixed",
         configuredSessionKey: "fallback-session",
@@ -541,22 +614,15 @@ describe("openclaw gateway routing helpers", () => {
       wakeReason: "issue_assigned",
       runId: "run-1",
       issueId: "issue-1",
-      paperclipAgentId: "paperclip-agent-1",
-      adapterAgentId: "gateway-agent-1",
-      routingVariables: {
-        project: {
-          id: "project-1",
-          name: "Core Platform",
-          metadata: {
-            sessionKey: "project-session-1",
-          },
+      payloadTemplate: {
+        agentId: "gateway-agent-1",
+      },
+      project: {
+        id: "project-1",
+        name: "Core Platform",
+        metadata: {
+          sessionKey: "project-session-1",
         },
-        paperclipAgentId: "paperclip-agent-1",
-        adapterAgentId: "gateway-agent-1",
-        issueId: "issue-1",
-        runId: "run-1",
-        wakeSource: "assignment",
-        wakeReason: "issue_assigned",
       },
       fallback: {
         strategy: "fixed",
@@ -742,10 +808,13 @@ describe("openclaw gateway adapter execute", () => {
             sessionKeyRouting: [
               {
                 pattern: "assignment:*",
-                sessionKey: "route:{{project.metadata.sessionKey}}:{{paperclipAgentId}}:{{issueId}}",
+                sessionKey: "route:{{project.metadata.sessionKey}}:{{payloadTemplate.agentId}}:{{issueId}}",
               },
               { pattern: "*:*", sessionKey: "route:default" },
             ],
+            payloadTemplate: {
+              agentId: "agent-123",
+            },
             waitTimeoutMs: 2000,
           },
           {

--- a/ui/src/adapters/openclaw-gateway/routing-rules-editor.test.tsx
+++ b/ui/src/adapters/openclaw-gateway/routing-rules-editor.test.tsx
@@ -148,8 +148,7 @@ describe("RoutingRulesEditor", () => {
     expect(wakeReasons).toContain("issue_assigned");
     expect(wakeReasons).toContain("stale_checkout_run");
     expect(templateVariables).toEqual([
-      "paperclipAgentId",
-      "adapterAgentId",
+      "payloadTemplate.<key>",
       "issueId",
       "runId",
       "wakeSource",

--- a/ui/src/adapters/openclaw-gateway/routing-rules-editor.tsx
+++ b/ui/src/adapters/openclaw-gateway/routing-rules-editor.tsx
@@ -38,8 +38,7 @@ export const wakeReasons = [
 ];
 
 export const templateVariables = [
-  "paperclipAgentId",
-  "adapterAgentId",
+  "payloadTemplate.<key>",
   "issueId",
   "runId",
   "wakeSource",
@@ -175,7 +174,8 @@ export function RoutingRulesEditor({
                   <section>
                     <h4 className="font-medium mb-1">Template variables</h4>
                     <p className="text-xs text-muted-foreground mb-2">
-                      Use dot-path syntax for nested values (for example, <code>{"{{project.metadata.sessionKey}}"}</code>).
+                      Use dot-path syntax for nested values (for example, <code>{"{{payloadTemplate.agentId}}"}</code>{" "}
+                      and <code>{"{{project.metadata.sessionKey}}"}</code>).
                     </p>
                     <table className="w-full text-xs border border-border rounded-md overflow-hidden">
                       <tbody>
@@ -231,7 +231,7 @@ export function RoutingRulesEditor({
                     onCommit={(next) => onChange(replaceRule(rules, index, "sessionKey", next))}
                     immediate
                     className={inputClass}
-                    placeholder="paperclip:{{paperclipAgentId}}:{{issueId}}"
+                    placeholder="paperclip:{{payloadTemplate.agentId}}:{{issueId}}"
                   />
                 </div>
                 <div className="flex justify-end gap-2">


### PR DESCRIPTION
## Summary
- refactor `resolveSessionKeyFromRouting` to accept `payloadTemplate` and build routing variables using nested namespaces
- keep flat system variables (`issueId`, `runId`, `wakeSource`, `wakeReason`) and existing `project.*` dot-path behavior
- update OpenClaw execute call site to pass resolved `payloadTemplate` and remove legacy `paperclipAgentId`/`adapterAgentId` inputs
- update OpenClaw routing tests for `payloadTemplate.*` usage, including dot-path resolution and null/empty payloadTemplate coverage
- update routing rules editor help and placeholder examples to use `{{payloadTemplate.agentId}}`

## Scope
- 1 story (refactor only)
- no routing matcher/evaluation loop changes
- no dot-path/interpolation engine changes
- no DB schema/migration changes
- OpenClaw adapter only
