### PR TITLE
Implement per-agent apiKeyPath for OpenClaw gateway adapter

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -84,6 +84,7 @@ const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";
 const DEFAULT_CLIENT_VERSION = "paperclip";
 const DEFAULT_ROLE = "operator";
+const DEFAULT_CLAIMED_API_KEY_PATH = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
 
 const SENSITIVE_LOG_KEY_PATTERN =
   /(^|[_-])(auth|authorization|token|secret|password|api[_-]?key|private[_-]?key)([_-]|$)|^x-openclaw-(auth|token)$/i;
@@ -335,8 +336,11 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
   return paperclipEnv;
 }
 
-function buildWakeText(payload: WakePayload, paperclipEnv: Record<string, string>): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+function buildWakeText(
+  payload: WakePayload,
+  paperclipEnv: Record<string, string>,
+  claimedApiKeyPath: string,
+): string {
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -1052,7 +1056,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const wakePayload = buildWakePayload(ctx);
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
-  const wakeText = buildWakeText(wakePayload, paperclipEnv);
+  const apiKeyPath = nonEmpty(ctx.config.apiKeyPath) ?? DEFAULT_CLAIMED_API_KEY_PATH;
+  const wakeText = buildWakeText(wakePayload, paperclipEnv, apiKeyPath);
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);
   const configuredSessionKey = nonEmpty(ctx.config.sessionKey);

--- a/server/src/__tests__/invite-onboarding-text.test.ts
+++ b/server/src/__tests__/invite-onboarding-text.test.ts
@@ -113,4 +113,36 @@ describe("buildInviteOnboardingTextDocument", () => {
     expect(text).toContain("Message from inviter");
     expect(text).toContain("prioritize flaky test triage first");
   });
+
+  it("uses configured apiKeyPath from invite defaults when provided", () => {
+    const req = buildReq("localhost:3100");
+    const invite = {
+      id: "invite-4",
+      companyId: "company-1",
+      inviteType: "company_join",
+      allowedJoinTypes: "agent",
+      tokenHash: "hash",
+      defaultsPayload: {
+        agentDefaultsPayload: {
+          apiKeyPath: "~/agent-one/paperclip-claimed-api-key.json",
+        },
+      },
+      expiresAt: new Date("2026-03-05T00:00:00.000Z"),
+      invitedByUserId: null,
+      revokedAt: null,
+      acceptedAt: null,
+      createdAt: new Date("2026-03-04T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-04T00:00:00.000Z"),
+    } as const;
+
+    const text = buildInviteOnboardingTextDocument(req, "token-999", invite as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    });
+
+    expect(text).toContain("~/agent-one/paperclip-claimed-api-key.json");
+    expect(text).not.toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
+  });
 });

--- a/server/src/__tests__/invite-onboarding-text.test.ts
+++ b/server/src/__tests__/invite-onboarding-text.test.ts
@@ -145,4 +145,63 @@ describe("buildInviteOnboardingTextDocument", () => {
     expect(text).toContain("~/agent-one/paperclip-claimed-api-key.json");
     expect(text).not.toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
   });
+
+  it("uses top-level apiKeyPath from invite defaults when provided", () => {
+    const req = buildReq("localhost:3100");
+    const invite = {
+      id: "invite-5",
+      companyId: "company-1",
+      inviteType: "company_join",
+      allowedJoinTypes: "agent",
+      tokenHash: "hash",
+      defaultsPayload: {
+        apiKeyPath: "~/agent-two/paperclip-claimed-api-key.json",
+      },
+      expiresAt: new Date("2026-03-05T00:00:00.000Z"),
+      invitedByUserId: null,
+      revokedAt: null,
+      acceptedAt: null,
+      createdAt: new Date("2026-03-04T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-04T00:00:00.000Z"),
+    } as const;
+
+    const text = buildInviteOnboardingTextDocument(req, "token-555", invite as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    });
+
+    expect(text).toContain("~/agent-two/paperclip-claimed-api-key.json");
+    expect(text).not.toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
+  });
+
+  it("falls back to default apiKeyPath when configured path is empty", () => {
+    const req = buildReq("localhost:3100");
+    const invite = {
+      id: "invite-6",
+      companyId: "company-1",
+      inviteType: "company_join",
+      allowedJoinTypes: "agent",
+      tokenHash: "hash",
+      defaultsPayload: {
+        apiKeyPath: "   ",
+      },
+      expiresAt: new Date("2026-03-05T00:00:00.000Z"),
+      invitedByUserId: null,
+      revokedAt: null,
+      acceptedAt: null,
+      createdAt: new Date("2026-03-04T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-04T00:00:00.000Z"),
+    } as const;
+
+    const text = buildInviteOnboardingTextDocument(req, "token-666", invite as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    });
+
+    expect(text).toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
+  });
 });

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -456,8 +456,40 @@ describe("openclaw gateway adapter execute", () => {
       expect(String(payload?.message ?? "")).toContain("wake now");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_RUN_ID=run-123");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_TASK_ID=task-123");
+      expect(String(payload?.message ?? "")).toContain(
+        "~/.openclaw/workspace/paperclip-claimed-api-key.json",
+      );
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("uses configured apiKeyPath in wake text", async () => {
+    const gateway = await createMockGatewayServer();
+
+    try {
+      const result = await execute(
+        buildContext({
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          apiKeyPath: "~/custom/openclaw/paperclip-key.json",
+          waitTimeoutMs: 2000,
+        }),
+      );
+
+      expect(result.exitCode).toBe(0);
+      const payload = gateway.getAgentPayload();
+      expect(payload).toBeTruthy();
+      expect(String(payload?.message ?? "")).toContain(
+        "PAPERCLIP_API_KEY=<token from ~/custom/openclaw/paperclip-key.json>",
+      );
+      expect(String(payload?.message ?? "")).toContain(
+        "Load PAPERCLIP_API_KEY from ~/custom/openclaw/paperclip-key.json",
+      );
     } finally {
       await gateway.close();
     }

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -59,6 +59,8 @@ const INVITE_TOKEN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
 const INVITE_TOKEN_SUFFIX_LENGTH = 8;
 const INVITE_TOKEN_MAX_RETRIES = 5;
 const COMPANY_INVITE_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_CLAIMED_API_KEY_PATH =
+  "~/.openclaw/workspace/paperclip-claimed-api-key.json";
 
 function createInviteToken() {
   const bytes = randomBytes(INVITE_TOKEN_SUFFIX_LENGTH);
@@ -113,6 +115,21 @@ function readSkillMarkdown(skillName: string): string | null {
     }
   }
   return null;
+}
+
+function resolveClaimedApiKeyPathFromInviteDefaults(defaultsPayload: unknown) {
+  if (!isPlainObject(defaultsPayload)) return DEFAULT_CLAIMED_API_KEY_PATH;
+  const directPath = nonEmptyTrimmedString(
+    (defaultsPayload as Record<string, unknown>).apiKeyPath
+  );
+  if (directPath) return directPath;
+  const nestedDefaults = (defaultsPayload as Record<string, unknown>)
+    .agentDefaultsPayload;
+  if (!isPlainObject(nestedDefaults)) return DEFAULT_CLAIMED_API_KEY_PATH;
+  return (
+    nonEmptyTrimmedString((nestedDefaults as Record<string, unknown>).apiKeyPath) ??
+    DEFAULT_CLAIMED_API_KEY_PATH
+  );
 }
 
 function toJoinRequestResponse(row: typeof joinRequests.$inferSelect) {
@@ -903,6 +920,9 @@ function buildInviteOnboardingManifest(
     allowedHostnames: string[];
   }
 ) {
+  const claimedApiKeyPath = resolveClaimedApiKeyPathFromInviteDefaults(
+    invite.defaultsPayload
+  );
   const baseUrl = requestBaseUrl(req);
   const skillPath = "/api/skills/paperclip";
   const skillUrl = baseUrl ? `${baseUrl}${skillPath}` : skillPath;
@@ -931,8 +951,9 @@ function buildInviteOnboardingManifest(
     invite: toInviteSummaryResponse(req, token, invite),
     onboarding: {
       instructions:
-        "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ~/.openclaw/workspace/paperclip-claimed-api-key.json and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).",
+        `Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ${claimedApiKeyPath} and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).`,
       inviteMessage: extractInviteMessage(invite),
+      apiKeyPath: claimedApiKeyPath,
       recommendedAdapterType: "openclaw_gateway",
       requiredFields: {
         requestType: "agent",
@@ -997,6 +1018,7 @@ export function buildInviteOnboardingTextDocument(
   const manifest = buildInviteOnboardingManifest(req, token, invite, opts);
   const onboarding = manifest.onboarding as {
     inviteMessage?: string | null;
+    apiKeyPath?: string;
     registrationEndpoint: { method: string; path: string; url: string };
     claimEndpointTemplate: { method: string; path: string };
     textInstructions: { path: string; url: string };
@@ -1011,6 +1033,8 @@ export function buildInviteOnboardingTextDocument(
   const diagnostics = Array.isArray(onboarding.connectivity?.diagnostics)
     ? onboarding.connectivity.diagnostics
     : [];
+  const claimedApiKeyPath =
+    nonEmptyTrimmedString(onboarding.apiKeyPath) ?? DEFAULT_CLAIMED_API_KEY_PATH;
 
   const lines: string[] = [];
   const appendBlock = (block: string) => {
@@ -1134,8 +1158,8 @@ export function buildInviteOnboardingTextDocument(
 
     On successful claim, save the full JSON response to:
 
-    - ~/.openclaw/workspace/paperclip-claimed-api-key.json
-    chmod 600 ~/.openclaw/workspace/paperclip-claimed-api-key.json
+    - ${claimedApiKeyPath}
+    chmod 600 ${claimedApiKeyPath}
 
     And set the PAPERCLIP_API_KEY and PAPERCLIP_API_URL in your environment variables as specified here:
     https://docs.openclaw.ai/help/environment


### PR DESCRIPTION
## Summary
- wire OpenClaw gateway wake text to use `ctx.config.apiKeyPath` when provided
- keep fallback to `~/.openclaw/workspace/paperclip-claimed-api-key.json` when unset/empty
- update invite/onboarding instruction generation to honor configured apiKeyPath (top-level and nested defaults) with default fallback
- add adapter and onboarding tests for custom path + fallback behavior

## Verification
- `pnpm -r typecheck` ✅
- `pnpm build` ✅
- `pnpm test:run` ⚠️ fails in existing worktree/git-hook tests unrelated to this change (`src/__tests__/worktree.test.ts`, `server/src/__tests__/workspace-runtime.test.ts`) due local git pre-commit policy blocking commits to `master` in test temp repos
